### PR TITLE
Fix Issue#198

### DIFF
--- a/dbux-code/src/codeUtil/codeSelection.js
+++ b/dbux-code/src/codeUtil/codeSelection.js
@@ -65,26 +65,7 @@ function handleCursorChanged() {
 // init
 // ###########################################################################
 
-function maybeClearSelectedTrace() {
-  if (traceSelection.selected &&
-    !allApplications.selection.containsApplication(traceSelection.selected.applicationId)) {
-    // deselect
-    traceSelection.selectTrace(null);
-  }
-}
-
 export function initTraceSelection(/* context */) {
-  // unselect trace if its not in a selected application anymore
-  allApplications.selection.onApplicationsChanged((selectedApps) => {
-    // TODO: clearing the selected trace does not belong here...
-    maybeClearSelectedTrace();
-    for (const app of selectedApps) {
-      allApplications.selection.subscribe(
-        app.dataProvider.onData('traces', maybeClearSelectedTrace)
-      );
-    }
-  });
-
   // show + goto trace if selected
   traceSelection.onTraceSelectionChanged((selectedTrace, sender) => {
     highlightTraceInEditor(selectedTrace);

--- a/dbux-code/src/graphView/GraphWebView.js
+++ b/dbux-code/src/graphView/GraphWebView.js
@@ -52,7 +52,7 @@ export default class GraphWebView extends WebviewWrapper {
     restart: this.restart,
 
     logClientError(args) {
-      logError('[CLIENT ERORR]', ...args);
+      logError('[CLIENT ERROR]', ...args);
     },
 
     async confirm(message, modal = true) {

--- a/dbux-common/src/util/scheduling.js
+++ b/dbux-common/src/util/scheduling.js
@@ -3,13 +3,13 @@
  */
 export function makeDebounce(cb, ms = 300) {
   let timer;
-  function _wrapDebounce() {
+  function _wrapDebounce(...args) {
     timer = null;
-    cb();
+    cb(...args);
   }
-  return () => {
+  return (...args) => {
     if (!timer) {
-      timer = setTimeout(_wrapDebounce, ms);
+      timer = setTimeout(() => _wrapDebounce(...args), ms);
     }
   };
 }

--- a/dbux-data/src/applications/ApplicationSelection.js
+++ b/dbux-data/src/applications/ApplicationSelection.js
@@ -1,0 +1,17 @@
+import ApplicationSet from './ApplicationSet';
+import traceSelection from '../traceSelection/index';
+
+export default class ApplicationSelection extends ApplicationSet {
+  _notifyChanged() {
+    let selectedTrace = traceSelection.selected;
+    if (selectedTrace && !this.containsApplication(selectedTrace.applicationId)) {
+      // specially handle traceSelection when deselecting app of selectedTrace
+      traceSelection._setSelectTrace(null);
+      super._notifyChanged();
+      traceSelection._emitSelectionChangedEvent('ApplicationSelection');
+    }
+    else {
+      super._notifyChanged();
+    }
+  }
+}

--- a/dbux-data/src/applications/allApplications.js
+++ b/dbux-data/src/applications/allApplications.js
@@ -3,7 +3,7 @@ import isString from 'lodash/isString';
 import { newLogger } from '@dbux/common/src/log/logger';
 
 import Application from './Application';
-import ApplicationSet from './ApplicationSet';
+import ApplicationSelection from './ApplicationSelection';
 
 // eslint-disable-next-line no-unused-vars
 // eslint-disable-next-line no-unused-vars
@@ -30,7 +30,7 @@ export class AllApplications {
   _emitter = new NanoEvents();
 
   constructor() {
-    this.applicationSelection = new ApplicationSet(this);
+    this.applicationSelection = new ApplicationSelection(this);
   }
 
   getAllCount() {

--- a/dbux-data/src/traceSelection/index.js
+++ b/dbux-data/src/traceSelection/index.js
@@ -11,9 +11,16 @@ export class TraceSelection {
   }
 
   selectTrace(trace, sender = null, args) {
-    this.selected = trace;
+    this._setSelectTrace(trace);
+    this._emitSelectionChangedEvent(sender, args);
+  }
 
-    this._emitter.emit('selectionChanged', trace, sender, args);
+  _setSelectTrace(trace) {
+    this.selected = trace;
+  }
+
+  _emitSelectionChangedEvent(sender = null, args) {
+    this._emitter.emit('selectionChanged', this.selected, sender, args);
   }
 
   onTraceSelectionChanged(cb) {

--- a/dbux-graph-client/src/componentLib/ClientComponentEndpoint.js
+++ b/dbux-graph-client/src/componentLib/ClientComponentEndpoint.js
@@ -83,7 +83,8 @@ class ClientComponentEndpoint extends ComponentEndpoint {
       await this.update();
     }
     catch (err) {
-      this.logger.error('Component update failed', err);
+      this.logger.warn('Component update failed', err);
+      throw err;
     }
   }
 

--- a/dbux-graph-common/src/componentLib/Ipc.js
+++ b/dbux-graph-common/src/componentLib/Ipc.js
@@ -101,9 +101,9 @@ export default class Ipc {
       args
     } = message;
 
-    const info = 'Failed to process request - ';
-    logError(info + commandName, args);
-    logError(err.stack);
+    const info = 'Error when processing request - ';
+    // logError(info + commandName, args);
+    // logError(err.stack);
     this._sendReply('reject', callId, componentId, info + err.message);
   }
 

--- a/dbux-graph-host/src/componentLib/HostComponentEndpoint.js
+++ b/dbux-graph-host/src/componentLib/HostComponentEndpoint.js
@@ -236,7 +236,7 @@ class HostComponentEndpoint extends ComponentEndpoint {
         },
         (err) => {
           // error :(
-          this.logger.error('error when updating client\n  ', err);
+          this.logger.error('Error when updating client, check client for stack trace.');
         }
       ).
       finally(() => {
@@ -260,28 +260,28 @@ class HostComponentEndpoint extends ComponentEndpoint {
   dispose(silent = false) {
     super.dispose();
 
-    Promise.resolve(this.waitForInit()).then(() => {
-      if (!this.isInitialized) {
-        throw new Error(this.debugTag + ' Trying to dispose before initialized');
-      }
-      for (const component of this.children) {
-        component.dispose(silent);
-      }
-      for (const component of this.controllers) {
-        component.dispose(silent);
-      }
+    // Promise.resolve(this.waitForInit()).then(() => {
+    if (!this.isInitialized) {
+      throw new Error(this.debugTag + ' Trying to dispose before initialized');
+    }
+    for (const component of this.children) {
+      component.dispose(silent);
+    }
+    for (const component of this.controllers) {
+      component.dispose(silent);
+    }
 
-      // remove from parent
-      if (this.owner) {
-        const list = this.owner._getComponentListByRoleName(this._internalRoleName);
-        list._removeComponent(this);
-      }
+    // remove from parent
+    if (this.owner) {
+      const list = this.owner._getComponentListByRoleName(this._internalRoleName);
+      list._removeComponent(this);
+    }
 
-      if (!silent) {
-        // also dispose on client
-        this._remoteInternal.dispose();
-      }
-    });
+    if (!silent) {
+      // also dispose on client
+      this._remoteInternal.dispose();
+    }
+    // });
   }
 
   // ###########################################################################

--- a/dbux-graph-host/src/components/GraphDocument.js
+++ b/dbux-graph-host/src/components/GraphDocument.js
@@ -21,7 +21,6 @@ class GraphDocument extends HostComponentEndpoint {
         allApplications.selection.incBusy();
         
         this.graphRoot.refresh();
-        this.controllers.getComponent(HighlightManager).clearDisposedHighlighter();
 
         if (this.componentManager.isBusyInit()) {
           const unbind = this.componentManager.onBusyStateChanged((state) => {

--- a/dbux-graph-host/src/components/controllers/FocusController.js
+++ b/dbux-graph-host/src/components/controllers/FocusController.js
@@ -108,8 +108,6 @@ export default class FocusController extends HostComponentEndpoint {
 
   highlight(node) {
     this.highlightManager.clear();
-    // we clear all highlighter before highlight, so no need to dec lastHighlighter here
-    // this.lastHighlighter.dec();
     this.lastHighlighter = node.controllers.getComponent('Highlighter');
     this.lastHighlighter.inc();
   }

--- a/dbux-graph-host/src/components/controllers/HighlightManager.js
+++ b/dbux-graph-host/src/components/controllers/HighlightManager.js
@@ -1,4 +1,5 @@
 import NanoEvents from 'nanoevents';
+import { makeDebounce } from '@dbux/common/src/util/scheduling';
 import HostComponentEndpoint from '../../componentLib/HostComponentEndpoint';
 
 export default class HighlightManager extends HostComponentEndpoint {
@@ -24,18 +25,9 @@ export default class HighlightManager extends HostComponentEndpoint {
     this._emitter.on(eventName, cb);
   }
 
-  _highlighterUpdated(newState) {
+  _highlighterUpdated = makeDebounce((newState) => {
     this.setState({
       highlightAmount: this.state.highlightAmount + newState
     });
-  }
-
-  clearDisposedHighlighter = () => {
-    for (const highlighter of this.allHighlighter) {
-      if (highlighter.isDisposed) this.allHighlighter.delete(highlighter);
-    }
-    this.setState({
-      highlightAmount: this.allHighlighter.size
-    });
-  }
+  }, 50);
 }

--- a/dbux-graph-host/src/components/controllers/Highlighter.js
+++ b/dbux-graph-host/src/components/controllers/Highlighter.js
@@ -7,6 +7,11 @@ export default class Highlighter extends HostComponentEndpoint {
 
   init() {
     this.state.enabled = 0;
+    this.addDisposable(() => {
+      if (this.state.enabled > 0) {
+        this.manager.registHighlight(this, -1);
+      }
+    });
   }
 
   inc() {


### PR DESCRIPTION
## Cause
When deselecting app of selectedTrace, focusController will try to call `this.lastHighlighter.dec`, but it's actually disposed due to `GraphRoot.refresh`. Note that children's `ComponentEndpoint._isDisposed` are set in a promise, thus may be inaccurate.

## Changes

### Makes WebView error log more clear
- Ipc will pass the error without logging, this reduces duplicate error message since caller also handle and log it.
- Client now throw error and warn instead of only logError, thus the error will be passed to host directly and the error can be captured in HostComponentEndpoint._executeUpdate

### Add disposable to Highlighter
- Automatically register -1 to highlightManager on disposed, thus hightlightManager wont hold disposed components.
- Remove `clearDisposedHighlighter`

### Handle deselect trace carefully
- Move `maybeClearSelectedTrace` to dbux-data. Before `ApplicationSelection._notifyChanged`, first set selectedTrace to null, then emit applicationChanged event, finally traceSelectionChanged event.

### Synchronize ComponentEndpoint.dispose (remove the promise part)
- Thus ComponentEndpoint._isDisposed can be set immediately

### Let makeDebounce passing arguments


#198