### PR TITLE
Issue#228

### DIFF
--- a/dbux-common/src/util/scheduling.js
+++ b/dbux-common/src/util/scheduling.js
@@ -1,32 +1,27 @@
+import { newLogger } from '@dbux/common/src/log/logger';
+
+// eslint-disable-next-line no-unused-vars
+const { log, debug, warn, error: logError } = newLogger('makeDebounce');
+
 /**
  * Make sure, function is not called more than once every `ms` milliseconds.
  */
+// eslint-disable-next-line camelcase
 export function makeDebounce(cb, ms = 300) {
   let timer;
-  function _wrapDebounce(...args) {
+  function _wrapDebounce() {
     timer = null;
-    cb(...args);
+    try {
+      cb();
+    }
+    catch (err) {
+      logError('Error when executing callback', 
+        cb.name?.trim() || '(anonymous callback)', '-', err);
+    }
   }
-  return (...args) => {
+  return () => {
     if (!timer) {
-      timer = setTimeout(() => _wrapDebounce(...args), ms);
+      timer = setTimeout(_wrapDebounce, ms);
     }
-  };
-}
-
-/**
- * Similar to `makeDebounce`, but delay the first call if another call comes in `ms` milliseconds.
- */
-export function makeDelayDebounce(cb, ms = 300) {
-  let timer;
-  function _wrapDebounce(...args) {
-    timer = null;
-    cb(...args);
-  }
-  return (...args) => {
-    if (timer) {
-      clearTimeout(timer);
-    }
-    timer = setTimeout(() => _wrapDebounce(...args), ms);
   };
 }

--- a/dbux-common/src/util/scheduling.js
+++ b/dbux-common/src/util/scheduling.js
@@ -13,3 +13,20 @@ export function makeDebounce(cb, ms = 300) {
     }
   };
 }
+
+/**
+ * Similar to `makeDebounce`, but delay the first call if another call comes in `ms` milliseconds.
+ */
+export function makeDelayDebounce(cb, ms = 300) {
+  let timer;
+  function _wrapDebounce(...args) {
+    timer = null;
+    cb(...args);
+  }
+  return (...args) => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => _wrapDebounce(...args), ms);
+  };
+}

--- a/dbux-graph-host/src/components/controllers/FocusController.js
+++ b/dbux-graph-host/src/components/controllers/FocusController.js
@@ -2,7 +2,14 @@ import NanoEvents from 'nanoevents';
 import traceSelection from '@dbux/data/src/traceSelection';
 import HostComponentEndpoint from '../../componentLib/HostComponentEndpoint';
 
+/** @typedef {import('./Highlighter').default} Highlighter */
+
 export default class FocusController extends HostComponentEndpoint {
+  /**
+   * @type {Highlighter}
+   */
+  lastHighlighter;
+
   get highlightManager() {
     return this.context.graphDocument.controllers.getComponent('HighlightManager');
   }
@@ -35,7 +42,7 @@ export default class FocusController extends HostComponentEndpoint {
       const { applicationId, contextId } = trace;
       contextNode = this.owner.getContextNodeById(applicationId, contextId);
       if (this.syncMode) {
-        this.focus(contextNode);
+        await this.focus(contextNode);
       }
     }
     else {

--- a/dbux-graph-host/src/components/controllers/HighlightManager.js
+++ b/dbux-graph-host/src/components/controllers/HighlightManager.js
@@ -1,5 +1,5 @@
 import NanoEvents from 'nanoevents';
-import { makeDelayDebounce } from '@dbux/common/src/util/scheduling';
+import { makeDebounce } from '@dbux/common/src/util/scheduling';
 import { newLogger } from '@dbux/common/src/log/logger';
 import HostComponentEndpoint from '../../componentLib/HostComponentEndpoint';
 
@@ -14,8 +14,12 @@ export default class HighlightManager extends HostComponentEndpoint {
   }
 
   registHighlight(highlighter, newState) {
-    if (newState === 1) this.allHighlighter.add(highlighter);
-    else this.allHighlighter.delete(highlighter);
+    if (newState === 1) {
+      this.allHighlighter.add(highlighter);
+    }
+    else {
+      this.allHighlighter.delete(highlighter);
+    }
 
     this._highlighterUpdated();
   }
@@ -29,11 +33,10 @@ export default class HighlightManager extends HostComponentEndpoint {
     this._emitter.on(eventName, cb);
   }
 
-  _highlighterUpdated = makeDelayDebounce(() => {
-    const size = this.allHighlighter.size();
+  _highlighterUpdated = makeDebounce(() => {
+    const { size } = this.allHighlighter;
     this.setState({
       highlightAmount: size
     });
-    debug('size', size);
   }, 50);
 }

--- a/dbux-graph-host/src/components/controllers/HighlightManager.js
+++ b/dbux-graph-host/src/components/controllers/HighlightManager.js
@@ -1,6 +1,10 @@
 import NanoEvents from 'nanoevents';
-import { makeDebounce } from '@dbux/common/src/util/scheduling';
+import { makeDelayDebounce } from '@dbux/common/src/util/scheduling';
+import { newLogger } from '@dbux/common/src/log/logger';
 import HostComponentEndpoint from '../../componentLib/HostComponentEndpoint';
+
+// eslint-disable-next-line no-unused-vars
+const { log, debug, warn, error: logError } = newLogger('HighlightManager');
 
 export default class HighlightManager extends HostComponentEndpoint {
   init() {
@@ -13,7 +17,7 @@ export default class HighlightManager extends HostComponentEndpoint {
     if (newState === 1) this.allHighlighter.add(highlighter);
     else this.allHighlighter.delete(highlighter);
 
-    this._highlighterUpdated(newState);
+    this._highlighterUpdated();
   }
 
   clear() {
@@ -25,9 +29,11 @@ export default class HighlightManager extends HostComponentEndpoint {
     this._emitter.on(eventName, cb);
   }
 
-  _highlighterUpdated = makeDebounce((newState) => {
+  _highlighterUpdated = makeDelayDebounce(() => {
+    const size = this.allHighlighter.size();
     this.setState({
-      highlightAmount: this.state.highlightAmount + newState
+      highlightAmount: size
     });
+    debug('size', size);
   }, 50);
 }


### PR DESCRIPTION
## Causes

Last changes to `HighlightManager` wraps `_highlighterUpdated` in `makeDebounce` with argument, which makes it only call once in with first argument and the skips the latest update.

## Changes

### More safe `makeDebounce`
* Add try-catch to handle errors in callback
* Rollback to old version which do not take arguments(callback should use variable in closure instead of pass it as argument)

### Fix SyncMode
* In `HighlightManager`, use `this.allHighlighter.size` instead of managing `highlightAmount` state