### PR TITLE
Fix issue 253

### DIFF
--- a/dbux-graph-host/src/components/controllers/FocusController.js
+++ b/dbux-graph-host/src/components/controllers/FocusController.js
@@ -31,17 +31,19 @@ export default class FocusController extends HostComponentEndpoint {
     const unbindSubscription = traceSelection.onTraceSelectionChanged(this.handleTraceSelected);
     this.addDisposable(unbindSubscription);
     // if already selected, show things right away
-    this.handleTraceSelected(traceSelection.selected);
+    setTimeout(this.handleTraceSelected);
   }
 
-  handleTraceSelected = async (trace) => {
+  handleTraceSelected = async () => {
+    const trace = traceSelection.selected;
     await this.waitForInit();
     
     let contextNode;
     if (trace) {
       const { applicationId, contextId } = trace;
       contextNode = this.owner.getContextNodeById(applicationId, contextId);
-      if (this.syncMode) {
+      if (this.syncMode && contextNode) {
+        // NOTE: since we do this right after init, need to check if contextNode have been built
         await this.focus(contextNode);
       }
     }
@@ -54,7 +56,7 @@ export default class FocusController extends HostComponentEndpoint {
   }
 
   handleHiddenNodeChanged = () => {
-    this.handleTraceSelected(traceSelection.selected);
+    this.handleTraceSelected();
   }
 
   _selectContextNode(contextNode) {
@@ -83,7 +85,7 @@ export default class FocusController extends HostComponentEndpoint {
     }
     this.syncMode = mode;
     if (this.syncMode) {
-      this.handleTraceSelected(traceSelection.selected);
+      this.handleTraceSelected();
     }
     else {
       this.lastHighlighter?.dec();

--- a/dbux-graph-host/src/components/controllers/FocusController.js
+++ b/dbux-graph-host/src/components/controllers/FocusController.js
@@ -1,6 +1,10 @@
 import NanoEvents from 'nanoevents';
+import { newLogger } from '@dbux/common/src/log/logger';
 import traceSelection from '@dbux/data/src/traceSelection';
 import HostComponentEndpoint from '../../componentLib/HostComponentEndpoint';
+
+// eslint-disable-next-line no-unused-vars
+const { log, debug, warn, error: logError } = newLogger('FocusController');
 
 /** @typedef {import('./Highlighter').default} Highlighter */
 
@@ -31,28 +35,35 @@ export default class FocusController extends HostComponentEndpoint {
     const unbindSubscription = traceSelection.onTraceSelectionChanged(this.handleTraceSelected);
     this.addDisposable(unbindSubscription);
     // if already selected, show things right away
-    setTimeout(this.handleTraceSelected);
+    this.handleTraceSelected();
   }
 
   handleTraceSelected = async () => {
-    const trace = traceSelection.selected;
-    await this.waitForInit();
-    
-    let contextNode;
-    if (trace) {
-      const { applicationId, contextId } = trace;
-      contextNode = this.owner.getContextNodeById(applicationId, contextId);
-      if (this.syncMode && contextNode) {
-        // NOTE: since we do this right after init, need to check if contextNode have been built
-        await this.focus(contextNode);
+    try {
+      // since we can't use async function in event handler, we should wrap it with try catch to capture error
+      const trace = traceSelection.selected;
+      await this.waitForInit();
+      
+      let contextNode;
+      if (trace) {
+        const { applicationId, contextId } = trace;
+        contextNode = this.owner.getContextNodeById(applicationId, contextId);
+        if (this.syncMode && contextNode) {
+          // NOTE: since we do this right after init, need to check if contextNode have been built
+          await this.focus(contextNode);
+        }
       }
+      else {
+        this.clearFocus();
+      }
+  
+      // always decorate ContextNode
+      this._selectContextNode(contextNode);
     }
-    else {
-      this.clearFocus();
+    catch (err) {
+      logError(err);
+      throw err;
     }
-
-    // always decorate ContextNode
-    this._selectContextNode(contextNode);
   }
 
   handleHiddenNodeChanged = () => {

--- a/dbux-graph-host/src/components/controllers/HighlightManager.js
+++ b/dbux-graph-host/src/components/controllers/HighlightManager.js
@@ -34,9 +34,11 @@ export default class HighlightManager extends HostComponentEndpoint {
   }
 
   _highlighterUpdated = makeDebounce(() => {
-    const { size } = this.allHighlighter;
-    this.setState({
-      highlightAmount: size
-    });
+    if (!this.isDisposed) {
+      const { size } = this.allHighlighter;
+      this.setState({
+        highlightAmount: size
+      });
+    }
   }, 50);
 }


### PR DESCRIPTION
## Causes
- `Highlighter`s will try to regist -1 to `highlightManager` after dispose, but `highlightManager` is already disposed.

### Another problem: Rejected unhandled promise within 1 second: Cannot read property 'isHiddenBy' of undefined
- `FocusController` will try to focus on selected trace at init, but `contextNode` might not have been built

## Changes

### `HighlightManager` should check dispose status in `_highlighterUpdated`

### Check if contextNode exist before focus
- NOTE: hiddenNodeManager will fire `stateChanged` event and cause `FocusController` to re-focus, which make this feature still work, thus temporarily solve this problem

#253
