### PR TITLE
Make sure `dbux_project` folder exist when cloning

### DIFF
--- a/dbux-projects/src/projectLib/BugRunner.js
+++ b/dbux-projects/src/projectLib/BugRunner.js
@@ -54,9 +54,7 @@ export default class BugRunner {
       throw new Error('already running');
     }
 
-    // make sure, `projectsRoot` exists
-    const { projectsRoot } = this.manager.config;
-    sh.mkdir('-p', projectsRoot);
+    this.createMainFolder();
 
     this._queue = new SerialTaskQueue('BugRunnerQueue');
 
@@ -67,6 +65,12 @@ export default class BugRunner {
     //   'testBug',
     //   // 'exec'
     // );
+  }
+
+  createMainFolder() {
+    // make sure, `projectsRoot` exists
+    const { projectsRoot } = this.manager.config;
+    sh.mkdir('-p', projectsRoot);
   }
 
   // _wrapSynchronized(f) {

--- a/dbux-projects/src/projectLib/Project.js
+++ b/dbux-projects/src/projectLib/Project.js
@@ -380,6 +380,7 @@ This may be solved by pressing \`clean project folder\` button.`);
       // this.log(`Cloning from "${githubUrl}"\n  in "${curDir}"...`);
       // project does not exist yet
       try {
+        this.runner.createMainFolder();
         await this.execInTerminal(`git clone "${githubUrl}" "${projectPath}"`, {
           cwd: this.projectsRoot
         });


### PR DESCRIPTION
Error reproduce: 
1. Start dbux.
2. Delete `dbux_project`.
3. Start any bug.
4. Error when cloning since this folder does not exist.

Fix: 
* Check if folder exist every time when cloning.