### PR TITLE
fix infinite loop in survey dialog

### DIFF
--- a/dbux-code/src/dialogs/Dialog.js
+++ b/dbux-code/src/dialogs/Dialog.js
@@ -101,7 +101,7 @@ export class Dialog {
         // handle goTo passed to enter
         nextState = this._gotoState;
         edgeLabel = null;
-        this.gotoState = null;
+        this._gotoState = null;
       }
       else {
         const edgeData = await NodeClass.render(this, node);
@@ -110,8 +110,16 @@ export class Dialog {
         }
         if (edgeData) {
           await edgeData.edge.click?.(...this._getUserCbArguments(node));
-          nextState = await this.maybeGetByFunction(edgeData.edge.node, node) || nodeName;
-          edgeLabel = edgeData.edgeLabel;
+          if (this._gotoState) {
+            // handle goTo passed to enter
+            nextState = this._gotoState;
+            edgeLabel = null;
+            this._gotoState = null;
+          }
+          else {
+            nextState = await this.maybeGetByFunction(edgeData.edge.node, node) || nodeName;
+            edgeLabel = edgeData.edgeLabel;
+          }
         }
         else {
           nextState = null;

--- a/dbux-code/src/dialogs/survey1.js
+++ b/dbux-code/src/dialogs/survey1.js
@@ -153,15 +153,17 @@ const survey1 = {
     waitToStart: {
       start: true,
       kind: DialogNodeKind.Message,
-      async enter(graphState, stack, { waitAtMost }) {
+      async enter(graphState, stack, { waitAtMost, goTo }) {
         const waitDelay = 1 * 60 * 60;
         const projectManager = getOrCreateProjectManager();
         const firstBug = projectManager.projects.getByName('express').getOrLoadBugs().getAt(0);
-        return Promise.race([
+        await Promise.race([
           waitForBugSolved(firstBug),
           waitAtMost(waitDelay),
           waitForPracticeSessionStop()
         ]);
+
+        goTo('start');
       },
       async text() {
         return `Can we ask you 5 short questions (related to Debugging and/or your first impressions of Dbux)?`;


### PR DESCRIPTION
NOTE: `whySurveyEdge` is still not working, but this prevents the infinite loop, will come back to this after priority issues

#378
