### PR TITLE
Trace await values no matter what type it is

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -167,8 +167,9 @@
 			],
 			"program": "${workspaceFolder}/dbux-cli/bin/dbux.js",
 			"args": [
+        "run", 
 				"-d",
-				"-p",
+        "-p",
 				"${file}",
 			],
 			"restart": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -167,9 +167,9 @@
 			],
 			"program": "${workspaceFolder}/dbux-cli/bin/dbux.js",
 			"args": [
-        "run", 
+                                "run", 
 				"-d",
-        "-p",
+                                "-p",
 				"${file}",
 			],
 			"restart": true,

--- a/dbux-babel-plugin/src/visitors/awaitVisitor.js
+++ b/dbux-babel-plugin/src/visitors/awaitVisitor.js
@@ -53,8 +53,6 @@ export function awaitVisitEnter(path, state) {
     ids: { dbux }
   } = state;
 
-  debugger;
-
   const resumeId = addResumeContext(path, state);
   const staticId = state.contexts.addStaticContext(path, {
     type: StaticContextType.Await,
@@ -77,9 +75,7 @@ export function awaitVisitEnter(path, state) {
     preTraceId: t.numericLiteral(preTraceId),
     argument
   });
-  debugger;
   argumentPath.replaceWith(expressionReplacement);
-  debugger;
 
   const awaitReplacement = postAwaitTemplate({
     dbux,
@@ -88,8 +84,6 @@ export function awaitVisitEnter(path, state) {
     resumeTraceId: t.numericLiteral(resumeTraceId)
   });
   path.replaceWith(awaitReplacement);
-
-  debugger;
 
   // prevent infinite loop
   const newAwaitPath = path.get('arguments.0');

--- a/dbux-babel-plugin/src/visitors/traceVisitors.js
+++ b/dbux-babel-plugin/src/visitors/traceVisitors.js
@@ -300,8 +300,7 @@ const traceCfg = (() => {
     // await
     // ########################################
     AwaitExpression: [
-      Await,
-      // [['argument', ExpressionValue]]
+      Await
     ],
 
     // TODO: ParenthesizedExpression - https://github.com/babel/babel/blob/master/packages/babel-generator/src/generators/expressions.js#L27
@@ -673,11 +672,6 @@ function visit(direction, onTrace, instrumentors, path, state, cfg) {
 
   if (!instrumentationType && !children) {
     return;
-  }
-
-  // debugger;
-  if (path.node.type === 'AwaitExpression' || path.node.type === 'ExpressionStatement') {
-    // debugger;
   }
 
   // mark as visited;

--- a/dbux-babel-plugin/src/visitors/traceVisitors.js
+++ b/dbux-babel-plugin/src/visitors/traceVisitors.js
@@ -17,7 +17,7 @@ import { traceWrapExpression, buildTraceNoValue, traceCallExpression, instrument
 // import { loopVisitor } from './loopVisitors';
 import { isCallPath } from '../helpers/functionHelpers';
 import { functionVisitEnter } from './functionVisitor';
-import { awaitVisitEnter } from './awaitVisitor';
+import { awaitVisitEnter, awaitVisitExit } from './awaitVisitor';
 import { getNodeNames } from './nameVisitors';
 import { isPathInstrumented } from '../helpers/instrumentationHelper';
 
@@ -300,7 +300,8 @@ const traceCfg = (() => {
     // await
     // ########################################
     AwaitExpression: [
-      Await
+      Await,
+      // [['argument', ExpressionValue]]
     ],
 
     // TODO: ParenthesizedExpression - https://github.com/babel/babel/blob/master/packages/babel-generator/src/generators/expressions.js#L27
@@ -588,6 +589,7 @@ const exitInstrumentors = {
   ThrowArgument(path, state) {
     return wrapExpression(TraceType.ThrowArgument, path, state);
   },
+  Await: awaitVisitExit,
 };
 
 // ###########################################################################
@@ -671,6 +673,11 @@ function visit(direction, onTrace, instrumentors, path, state, cfg) {
 
   if (!instrumentationType && !children) {
     return;
+  }
+
+  // debugger;
+  if (path.node.type === 'AwaitExpression' || path.node.type === 'ExpressionStatement') {
+    // debugger;
   }
 
   // mark as visited;

--- a/samples/__samplesInput__/await_argument0.js
+++ b/samples/__samplesInput__/await_argument0.js
@@ -1,0 +1,16 @@
+
+3+4;
+
+let a = 4, b = 5, c = async () => {};
+
+async function f() {
+  await 42;
+  await g();
+  await a;
+  await (a + b);
+  await c;
+  await c();
+}
+
+f();
+function g() {};


### PR DESCRIPTION
Can use await_argument0.js to test. Every argument of await should be traced now.
Not fully tested but works (hope so).