### PR TITLE
Fix VSCode IntelliSense

### DIFF
--- a/dbux-cli/jsconfig.json
+++ b/dbux-cli/jsconfig.json
@@ -6,7 +6,11 @@
 		"checkJs": false, /* Typecheck .js files. */
 		"lib": [
 			"es6"
-		]
+    ],
+    "paths": {
+      "@dbux/common/*": ["../dbux-common/*"],
+      "@dbux/runtime/*": ["../dbux-runtime/*"]
+    }
 	},
 	"exclude": [
 		"node_modules"

--- a/dbux-code/jsconfig.json
+++ b/dbux-code/jsconfig.json
@@ -6,7 +6,15 @@
 		"checkJs": false, /* Typecheck .js files. */
 		"lib": [
 			"es6"
-		]
+		],
+    "paths": {
+      "@dbux/common/*": ["../dbux-common/*"],
+      "@dbux/data/*": ["../dbux-data/*"],
+      "@dbux/graph-common/*": ["../dbux-graph-common/*"],
+      "@dbux/graph-host/*": ["../dbux-graph-host/*"],
+      "@dbux/projects/*": ["../dbux-projects/*"],
+      "@dbux/runtime/*": ["../dbux-runtime/*"],
+    }
 	},
 	"exclude": [
 		"node_modules"

--- a/dbux-data/jsconfig.json
+++ b/dbux-data/jsconfig.json
@@ -5,7 +5,10 @@
 		"checkJs": false,  /* Typecheck .js files. */
 		"lib": [
 			"es6"
-		]
+    ],
+    "paths": {
+      "@dbux/common/*": ["../dbux-common/*"],
+    }
 	},
 	"exclude": [
 		"node_modules"

--- a/dbux-graph-common/jsconfig.json
+++ b/dbux-graph-common/jsconfig.json
@@ -2,7 +2,10 @@
 	"compilerOptions": {
 		"module": "esnext",
 		"target": "esnext",
-		"checkJs": false,  /* Typecheck .js files. */
+    "checkJs": false,  /* Typecheck .js files. */
+    "paths": {
+      "@dbux/common/*": ["../dbux-common/*"]
+    }
 	},
 	"include": [
 		"src", "src/**/*"

--- a/dbux-graph-host/jsconfig.json
+++ b/dbux-graph-host/jsconfig.json
@@ -5,7 +5,9 @@
 		"checkJs": false,  /* Typecheck .js files. */
 		"baseUrl": "./",
 		"paths": {
-			// "@/*": [ "src/*" ]
+      "@dbux/common/*": ["../dbux-common/*"],
+      "@dbux/data/*": ["../dbux-data/*"],
+      "@dbux/graph-common/*": ["../dbux-graph-common/*"]
 		}
 	},
 	"include": [

--- a/dbux-projects/jsconfig.json
+++ b/dbux-projects/jsconfig.json
@@ -5,7 +5,9 @@
 		"checkJs": false,  /* Typecheck .js files. */
 		"baseUrl": "./",
 		"paths": {
-			// "@/*": [ "src/*" ]
+			"@dbux/cli/*": ["../dbux-cli/*"],
+      "@dbux/common/*": ["../dbux-common/*"],
+      "@dbux/data/*": ["../dbux-data/*"]
 		},
 		"lib": [
 			"es6"

--- a/dbux-runtime/jsconfig.json
+++ b/dbux-runtime/jsconfig.json
@@ -5,7 +5,10 @@
 		"checkJs": false,  /* Typecheck .js files. */
 		"lib": [
 			"es6"
-		]
+    ],
+    "paths": {
+      "@dbux/common/*": ["../dbux-common/*"],
+    }
 	},
 	"exclude": [
 		"node_modules"


### PR DESCRIPTION
Simply add some configuration to `jsconfig.json` to get VSCode IntelliSense for import alias like '@dbux/common/...'