### PR TITLE
fix graph-client not rebuild

### DIFF
--- a/dbux-graph-client/package.json
+++ b/dbux-graph-client/package.json
@@ -12,8 +12,8 @@
     "start:prod": "npm run build:watch:prod",
     "build:prod": "node ../node_modules/webpack/bin/webpack --mode production",
     "build:dev": "node ../node_modules/webpack/bin/webpack --mode development",
-    "build:watch": "npx nodemon --exec \"node ../node_modules/webpack/bin/webpack\" --mode development --watch",
-    "build:watch:prod": "npx nodemon --exec \"node ../node_modules/webpack/bin/webpack\" --mode production --watch",
+    "build:watch": "npx nodemon --exec \"node ../node_modules/webpack/bin/webpack --mode development --watch\"",
+    "build:watch:prod": "npx nodemon --exec \"node ../node_modules/webpack/bin/webpack --mode production --watch\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
The `--watch` & `--mode` args should be in webpack sub-command instead of nodemon command, this way graph-client will rebuild as expected when files changed.