### PR TITLE
Fix error when no bash found

### DIFF
--- a/dbux-projects/src/checkSystem.js
+++ b/dbux-projects/src/checkSystem.js
@@ -39,6 +39,9 @@ function isChecked(/* manager */) {
 async function check(program) {
   try {
     let paths = await which(program);
+    if (!paths?.length) {
+      return {};
+    }
     return { path: paths[0], multiple: paths.length > 1 };
   } catch (err) {
     return {};


### PR DESCRIPTION
Fix #404.
Error due to `return null` in our `which` function (maybe).