### PR TITLE
Add setting of whitelisting packages to be instrumented

### DIFF
--- a/dbux-cli/src/commandCommons.js
+++ b/dbux-cli/src/commandCommons.js
@@ -30,6 +30,12 @@ export function buildCommonCommandOptions() {
       default: '',
       type: 'string',
     },
+    packageWhitelist: {
+      alias: ['w'],
+      describe: "Specify which packages will be instrumented.",
+      default: '',
+      // type: 'array',
+    }
   };
 }
 

--- a/dbux-cli/src/util/buildBabelOptions.js
+++ b/dbux-cli/src/util/buildBabelOptions.js
@@ -72,7 +72,7 @@ export default function buildBabelOptions(options) {
           return undefined;
         }
 
-        const matchSkipFileResult = modulePath.match(/dist|\.mjs/);
+        const matchSkipFileResult = modulePath.match(/([/\\]dist[/\\])|(\.mjs$)/);
         const matchResult = modulePath.match(/(?<=node_modules\/)(?!node_modules)(?<packageName>[^/]+)(?=\/(?!node_modules).*)/);
         const packageName = matchResult ? matchResult.groups.packageName : null;
 

--- a/dbux-cli/src/util/buildBabelOptions.js
+++ b/dbux-cli/src/util/buildBabelOptions.js
@@ -25,6 +25,14 @@ function debugLog(...args) {
   // }
 }
 
+/**
+ * Add `^` and `$` (if not exist) to `s` and convert to `RegExp`.
+ * @param {string} s 
+ */
+function generateFullMatchRegExp(s) {
+  return new RegExp(`${s[0] === '^' ? '' : '^'}${s}${s[s.length - 1] === '$' ? '' : '$'}`);
+}
+
 function batchTestRegExp(regexps, target) {
   return regexps.some(regexp => regexp.test(target));
 }
@@ -51,10 +59,9 @@ export default function buildBabelOptions(options) {
     dontInjectDbux,
     dontAddPresets,
     dbuxOptions: dbuxOptionsString,
+    packageWhitelist,
     verbose = 0
   } = options;
-
-  let { packageWhitelist } = options;
 
   if (dontInjectDbux && !esnext) {
     // nothing to babel
@@ -70,8 +77,7 @@ export default function buildBabelOptions(options) {
   //   injectDependencies();
   // }
 
-  if (!Array.isArray(packageWhitelist)) packageWhitelist = [packageWhitelist];
-  const packageWhitelistRegExps = packageWhitelist.map(packageName => new RegExp(`^${packageName}$`));
+  const packageWhitelistRegExps = packageWhitelist.split(',').map(s => s.trim()).map(generateFullMatchRegExp);
 
   // setup babel-register
   const baseOptions = esnext ? baseBabelOptions : EmptyObject;

--- a/dbux-cli/src/util/buildBabelOptions.js
+++ b/dbux-cli/src/util/buildBabelOptions.js
@@ -37,9 +37,10 @@ export default function buildBabelOptions(options) {
     dontInjectDbux,
     dontAddPresets,
     dbuxOptions: dbuxOptionsString,
-    packageWhitelist,
     verbose = 0
   } = options;
+
+  let { packageWhitelist } = options;
 
   if (dontInjectDbux && !esnext) {
     // nothing to babel
@@ -55,6 +56,7 @@ export default function buildBabelOptions(options) {
   //   injectDependencies();
   // }
 
+  if (!Array.isArray(packageWhitelist)) packageWhitelist = [packageWhitelist];
   const packageWhitelistRegExps = packageWhitelist.map(packageName => new RegExp(`^${packageName}$`));
 
   // setup babel-register

--- a/dbux-code/package.json
+++ b/dbux-code/package.json
@@ -1149,7 +1149,7 @@
           "dbux.packageWhitelist": {
             "type": "string",
             "default": "",
-            "description": "Specify which package will be traced by Dbux, seperated by comma, regex supported.",
+            "description": "Specify which package will be traced by Dbux, seperated by space, regex supported.",
             "scope": "resource"
           }
         }

--- a/dbux-code/package.json
+++ b/dbux-code/package.json
@@ -1145,6 +1145,12 @@
             "default": {},
             "description": "Custom program environment variables available via `process.env` (probably not working yet).",
             "scope": "resource"
+          },
+          "dbux.packageWhitelist": {
+            "type": "string",
+            "default": "",
+            "description": "Specify which package will be traced by Dbux, seperated by comma, regex supported.",
+            "scope": "resource"
           }
         }
       }

--- a/dbux-code/src/commands/runCommands.js
+++ b/dbux-code/src/commands/runCommands.js
@@ -47,7 +47,7 @@ function getArgs(debugMode) {
   dbuxArgs += `${parseEnv(env)}`;
 
   let packageWhitelists = config.get(`dbux.packageWhitelist`);
-  if (packageWhitelists) dbuxArgs += packageWhitelists.split(' ').map(packageName => ` -w ${packageName}`).join(' ');
+  if (packageWhitelists) dbuxArgs += ` -w '${packageWhitelists}'`;
 
   let programArgs = config.get(`dbux.${runMode}.programArgs`);
   if (programArgs) programArgs = ` ${programArgs}`;

--- a/dbux-code/src/commands/runCommands.js
+++ b/dbux-code/src/commands/runCommands.js
@@ -47,7 +47,7 @@ function getArgs(debugMode) {
   dbuxArgs += `${parseEnv(env)}`;
 
   let packageWhitelists = config.get(`dbux.packageWhitelist`);
-  if (packageWhitelists) dbuxArgs += packageWhitelists.split(',').map(packageName => ` -w ${packageName}`).join(' ');
+  if (packageWhitelists) dbuxArgs += packageWhitelists.split(' ').map(packageName => ` -w ${packageName}`).join(' ');
 
   let programArgs = config.get(`dbux.${runMode}.programArgs`);
   if (programArgs) programArgs = ` ${programArgs}`;

--- a/dbux-code/src/commands/runCommands.js
+++ b/dbux-code/src/commands/runCommands.js
@@ -46,6 +46,9 @@ function getArgs(debugMode) {
   let env = config.get(`dbux.${runMode}.env`);
   dbuxArgs += `${parseEnv(env)}`;
 
+  let packageWhitelists = config.get(`dbux.packageWhitelist`);
+  if (packageWhitelists) dbuxArgs += packageWhitelists.split(',').map(packageName => ` -w ${packageName}`).join(' ');
+
   let programArgs = config.get(`dbux.${runMode}.programArgs`);
   if (programArgs) programArgs = ` ${programArgs}`;
 


### PR DESCRIPTION
Resolves #460.
In `yargs` part, I choose not to add `type: 'array'` since it will take too many arguments and I don't know how to stop it from eating all arguments.

* still need to edit plugin part?
* need to check if passing regexp code in command line is good (escape?)