### PR TITLE
Split `nodeToggleBtn` into two

### DIFF
--- a/dbux-common/src/util/Enum.js
+++ b/dbux-common/src/util/Enum.js
@@ -146,7 +146,7 @@ export default class Enum {
   previousValue(value) {
     const { values } = this;
     let idx = values.indexOf(value);
-    idx = (idx - 1) % values.length;
+    idx = (idx - 1 + values.length) % values.length;
     return values[idx];
   }
 

--- a/dbux-graph-client/jsconfig.json
+++ b/dbux-graph-client/jsconfig.json
@@ -5,8 +5,9 @@
 		"checkJs": false,  /* Typecheck .js files. */
 		"baseUrl": "./",
 		"paths": {
-			// "@/*": [ "src/*" ]
-		}
+      "@dbux/common/*": ["../dbux-common/*"],
+      "@dbux/graph-common/*": ["../dbux-graph-common/*"],
+    }
 	},
 	"include": [
 		"src",

--- a/dbux-graph-client/src/graph/ContextNode.js
+++ b/dbux-graph-client/src/graph/ContextNode.js
@@ -17,7 +17,10 @@ class ContextNode extends ClientComponentEndpoint {
           <div class="content">
             <div class="flex-row">
               <div class="flex-row">
-                <button data-el="nodeToggleBtn" class="btn node-toggle-btn"></button>
+                <div class="mode-btn-wrapper">
+                  <button data-el="previousModeButton" class="btn graph-mode-button"></button>
+                  <button data-el="nextModeButton" class="btn graph-mode-button"></button>
+                </div>
                 <div data-el="parentLabel" class="ellipsis-20 dbux-link"></div>
                 <div data-el="title" class="flex-row" style="align-items: center">
                   <div data-el="contextLabel" class="ellipsis-20 dbux-link"></div>

--- a/dbux-graph-client/src/graph/GraphRoot.js
+++ b/dbux-graph-client/src/graph/GraphRoot.js
@@ -11,7 +11,8 @@ class GraphRoot extends ClientComponentEndpoint {
             <h4>Applications:</h4>
             <pre data-el="applications"></pre>
             <div>
-              <button data-el="nodeToggleBtn" class="nodeToggleBtn"></button>
+              <button data-el="previousModeButton" class="root-graph-mode-button"></button>
+              <button data-el="nextModeButton" class="root-graph-mode-button"></button>
             </div>
             <div data-mount="HiddenBeforeNode"></div>
             <div data-el="nodeChildren" data-mount="RunNode" class="node-children flex-column">

--- a/dbux-graph-client/src/graph/controllers/GraphNode.js
+++ b/dbux-graph-client/src/graph/controllers/GraphNode.js
@@ -5,7 +5,8 @@ import { decorateClasses } from '../../util/domUtil';
 export default class GraphNode extends ClientComponentEndpoint {
   init() {
     const {
-      nodeToggleBtn,
+      previousModeButton,
+      nextModeButton,
       nodeChildren
     } = this.owner.els;
 
@@ -22,7 +23,11 @@ export default class GraphNode extends ClientComponentEndpoint {
     // on click -> nextMode
     this.owner.dom.addEventListeners(this, true);
 
-    nodeToggleBtn?.addEventListener('click', (/* evt */) => {
+    previousModeButton?.addEventListener('click', (/* evt */) => {
+      this.remote.previousMode();
+    });
+
+    nextModeButton?.addEventListener('click', (/* evt */) => {
       this.remote.nextMode();
     });
   }
@@ -31,19 +36,19 @@ export default class GraphNode extends ClientComponentEndpoint {
     return this.owner.els.nodeToggleBtn;
   }
 
-  get listEl() {
+  get childrenEl() {
     return this.owner.els.nodeChildren;
   }
-  
+
   /**
    * NOTE: state.isExpanded might not always be mirrored by DOM (but we are trying to achieve just that here).
    */
   isDOMExpanded() {
-    return !this.listEl.classList.contains('hidden');
+    return !this.childrenEl.classList.contains('hidden');
   }
 
   isListEmpty() {
-    const { listEl } = this;
+    const { childrenEl: listEl } = this;
     return !listEl.children.length;
   }
 
@@ -51,14 +56,14 @@ export default class GraphNode extends ClientComponentEndpoint {
    * Hide button if list is empty
    */
   renderListEmptyState = () => {
-    const { btnEl, listEl } = this;
+    const { childrenEl } = this;
 
     // show/hide button
     // btnEl && decorateClasses(btnEl, {
     //   hidden: this.isListEmpty()
     // });
 
-    decorateClasses(listEl, {
+    decorateClasses(childrenEl, {
       hidden: this.isListEmpty()
     });
 
@@ -70,34 +75,60 @@ export default class GraphNode extends ClientComponentEndpoint {
   }
 
   render() {
-    const { listEl, btnEl, state: { mode } } = this;
+    const { childrenEl, state: { mode, buttonDisabled } } = this;
+    const { previousModeButton, nextModeButton } = this.owner.els;
 
     // if (this.isListEmpty()) {
     //   // button should already be hidden -> now also hide list
     //   listEl.classList.add('hidden');
     // }
-    if (!this.isListEmpty()) {
+    if (!buttonDisabled && !this.isListEmpty()) {
       switch (mode) {
         case GraphNodeMode.ExpandChildren:
-          listEl.classList.remove('hidden');
-          btnEl && (btnEl.innerHTML = '-');
+          childrenEl.classList.remove('hidden');
           break;
         case GraphNodeMode.ExpandSubgraph:
-          listEl.classList.remove('hidden');
-          btnEl && (btnEl.innerHTML = '☰');
+          childrenEl.classList.remove('hidden');
           break;
         case GraphNodeMode.Collapsed:
           // NOTE: cannot hide children if it has no button (for now)
-          btnEl && listEl.classList.add('hidden');
-          btnEl && (btnEl.innerHTML = '▷');
+          childrenEl.classList.add('hidden');
           break;
+      }
+
+      const previousMode = GraphNodeMode.previousValue(mode);
+      const nextMode = GraphNodeMode.nextValue(mode);
+      previousModeButton.textContent = this.getModeIcon(previousMode);
+      nextModeButton.textContent = this.getModeIcon(nextMode);
+      previousModeButton.disabled = false;
+      nextModeButton.disabled = false;
+      if (previousMode === GraphNodeMode.ExpandSubgraph && this.owner.children.computeMaxDepth() <= 1) {
+        previousModeButton.disabled = true;
+      }
+      else if (nextMode === GraphNodeMode.ExpandSubgraph && this.owner.children.computeMaxDepth() <= 1) {
+        nextModeButton.disabled = true;
       }
     }
   }
 
-  on = {
+  getModeIcon(mode) {
+    switch (mode) {
+      case GraphNodeMode.ExpandChildren:
+        return '-';
+      case GraphNodeMode.ExpandSubgraph:
+        return '☰';
+      case GraphNodeMode.Collapsed:
+        return '▷';
+      default:
+        return '';
+    }
+  }
 
-    nodeToggleBtn: {
+  on = {
+    previousModeButton: {
+      focus(evt) { evt.target.blur(); }
+    },
+    nextModeButton: {
       focus(evt) { evt.target.blur(); }
     }
   }

--- a/dbux-graph-client/src/graph/styles.css
+++ b/dbux-graph-client/src/graph/styles.css
@@ -29,7 +29,7 @@ html,body{
  * graph nodes
  * ############################################################################ */
 
-.graph-node .content button {
+ .mode-btn-wrapper .graph-mode-button {
   background-color: rgba(0,0,0,0.1);
   display:inline-block;
   margin:0;
@@ -38,7 +38,7 @@ html,body{
   line-height: 1rem;
   min-width: 1.4rem; /* NOTE: on some systems, some of those emojis are extra-wide */
 }
-.theme-mode-dark .nodeToggleBtn {
+.theme-mode-dark .root-graph-mode-button {
   background: #292929;
   border: solid 2px #484848;
   color: white;
@@ -192,8 +192,8 @@ html,body{
   margin-right: 0.3rem !important;
 }
 
-.node-toggle-btn {
-  margin-right: 0.3rem !important;
+.mode-btn-wrapper {
+  margin-right: 0.3rem;
 }
 
 .loc-label {

--- a/dbux-graph-host/src/graph/RunNode.js
+++ b/dbux-graph-host/src/graph/RunNode.js
@@ -16,7 +16,9 @@ class RunNode extends HostComponentEndpoint {
     const dp = allApplications.getById(applicationId).dataProvider;
 
     // add GraphNode
-    this.controllers.createComponent('GraphNode');
+    this.controllers.createComponent('GraphNode', {
+      buttonDisabled: true
+    });
 
     // add root context
     const firstContext = dp.util.getFirstContextOfRun(runId);

--- a/dbux-graph-host/src/graph/controllers/GraphNode.js
+++ b/dbux-graph-host/src/graph/controllers/GraphNode.js
@@ -56,17 +56,38 @@ export default class GraphNode extends HostComponentEndpoint {
     }
   }
 
+  getPreviousMode() {
+    let mode = GraphNodeMode.previousValue(this.state.mode);
+    if (mode === GraphNodeMode.ExpandSubgraph && this.owner.children.computeMaxDepth() <= 1) {
+      // skip "ExpandSubgraph" if there is only one level
+      mode = GraphNodeMode.previousValue(mode);
+    }
+    return mode;
+  }
+
+  getNextMode() {
+    let mode = GraphNodeMode.nextValue(this.state.mode);
+    if (mode === GraphNodeMode.ExpandSubgraph && this.owner.children.computeMaxDepth() <= 1) {
+      // skip "ExpandSubgraph" if there is only one level
+      mode = GraphNodeMode.nextValue(mode);
+    }
+    return mode;
+  }
+
   public = {
     setMode: this.setMode,
-    nextMode: () => {
-      let mode = GraphNodeMode.nextValue(this.state.mode);
-      if (mode === GraphNodeMode.ExpandSubgraph && this.owner.children.computeMaxDepth() <= 1) {
-        // skip "ExpandSubgraph" if there is only one level
-        mode = GraphNodeMode.nextValue(mode);
-      }
+    previousMode: () => {
+      let mode = this.getPreviousMode();
       const { firstTrace: trace } = this.owner;
       const { context } = this.owner.state;
-      this.componentManager.externals.emitCallGraphAction(UserActionType.CallGraphNodeCollapseChange, { context, trace });
+      this.componentManager.externals.emitCallGraphAction(UserActionType.CallGraphNodeCollapseChange, { mode, context, trace });
+      this.setMode(mode);
+    },
+    nextMode: () => {
+      let mode = this.getNextMode();
+      const { firstTrace: trace } = this.owner;
+      const { context } = this.owner.state;
+      this.componentManager.externals.emitCallGraphAction(UserActionType.CallGraphNodeCollapseChange, { mode, context, trace });
       this.setMode(mode);
     },
     reveal: this.reveal


### PR DESCRIPTION
**NOTE: There are still some problems in this PR.**

Since we want to lazy load the ContextNodes, `computeMaxDepth` will be inaccurate before we expand the node. `GraphNode.nextMode` will skip `ExpandSubgraph` even if there are some child contexts.

Also in this PR:
- fix `Enum.previousValue`
- fix import intellisense in `graph-client`

#455