### PR TITLE
Apply lazy load to all `ContextNode`

### DIFF
--- a/dbux-graph-host/src/graph/ContextNode.js
+++ b/dbux-graph-host/src/graph/ContextNode.js
@@ -10,10 +10,8 @@ import GraphNodeMode from '@dbux/graph-common/src/shared/GraphNodeMode';
 import HostComponentEndpoint from '../componentLib/HostComponentEndpoint';
 
 class ContextNode extends HostComponentEndpoint {
-  init(shouldLazyBuild = false) {
-    this.shouldLazyBuild = shouldLazyBuild;
+  init() {
     this.childrenBuilt = false;
-
     this.state.statsEnabled = true;
 
     const {
@@ -38,23 +36,11 @@ class ContextNode extends HostComponentEndpoint {
       this._addStats(this.state);
     }
     
-    // build sub graph
-    let hasChildren;
-    if (this.shouldLazyBuild) {
-      hasChildren = !!this.getValidChildContexts().length;
-    }
-    else {
-      this.buildChildNodes();
-      hasChildren = !!this.children.getComponents('ContextNode').length;
-    }
-
     // add controllers
+    let hasChildren = !!this.getValidChildContexts().length;
     this.controllers.createComponent('GraphNode', { hasChildren });
     this.controllers.createComponent('PopperController');
     this.controllers.createComponent('Highlighter');
-
-    // register with root
-    this.context.graphRoot._contextNodeCreated(this);
   }
 
   get dp() {
@@ -72,11 +58,6 @@ class ContextNode extends HostComponentEndpoint {
     return this.dp.util.getFirstTraceOfContext(this.contextId);
   }
 
-  // get contextChildrenAmount() {
-  // const contextChildren = this.children.getComponents('ContextNode');
-  // let amount = contextChildren.length;
-  // contextChildren.forEach(childNode => amount += childNode.contextChildrenAmount);
-  // return amount;
   get nTreeContexts() {
     const stats = this.dp.queries.statsByContext(this.contextId);
     return stats?.nTreeContexts || 0;
@@ -102,21 +83,6 @@ class ContextNode extends HostComponentEndpoint {
     _update.nTreeStaticContexts = this.nTreeStaticContexts;
   }
 
-  buildChildNodes() {
-    if (this.childrenBuilt) {
-      return this.children.getComponents('ContextNode');
-    }
-
-    this.childrenBuilt = true;
-    const { applicationId } = this.state;
-    return this.getValidChildContexts().map(context => {
-      return this.children.createComponent('ContextNode', {
-        applicationId,
-        context
-      });
-    });
-  }
-
   getValidChildContexts() {
     const { applicationId, context: { contextId } } = this.state;
     const dp = allApplications.getById(applicationId).dataProvider;
@@ -139,7 +105,7 @@ class ContextNode extends HostComponentEndpoint {
   }
 
   expand() {
-    this.controllers.getComponent('GraphNode').setOwnMode(GraphNodeMode.ExpandChildren);
+    this.controllers.getComponent('GraphNode').setMode(GraphNodeMode.ExpandChildren);
   }
 
   setSelected(isSelected) {

--- a/dbux-graph-host/src/graph/RootContextNode.js
+++ b/dbux-graph-host/src/graph/RootContextNode.js
@@ -1,7 +1,5 @@
 import ContextNode from './ContextNode';
 
 export default class RootContextNode extends ContextNode {
-  init() {
-    super.init(true);
-  }
+  
 }

--- a/dbux-graph-host/src/graph/RunNode.js
+++ b/dbux-graph-host/src/graph/RunNode.js
@@ -23,10 +23,7 @@ class RunNode extends HostComponentEndpoint {
     // add root context
     const firstContext = dp.util.getFirstContextOfRun(runId);
     if (firstContext) {
-      this.rootContextNode = this.children.createComponent('RootContextNode', {
-        applicationId,
-        context: firstContext
-      });
+      this.rootContextNode = this.context.graphRoot._buildContextNode(this, applicationId, firstContext, true);
       this.state.createdAt = dp.util.getRunCreatedAt(runId);
       this.state.firstContextId = firstContext.contextId;
     }

--- a/dbux-graph-host/src/graph/controllers/GraphNode.js
+++ b/dbux-graph-host/src/graph/controllers/GraphNode.js
@@ -38,7 +38,7 @@ export default class GraphNode extends HostComponentEndpoint {
   }
 
   setMode(mode) {
-    if (mode !== GraphNodeMode.Collapsed && !this.owner.childrenBuilt) {
+    if (mode !== GraphNodeMode.Collapsed && this.owner.childrenBuilt === false) {
       this.owner.context.graphRoot.buildContextNodeChildren(this.owner);
     }
 


### PR DESCRIPTION
After we find out that Components are built synchronously, we decided to apply the lazy load mechanism to all `ContextNode`s instead of introduce a new `isEnabled` logic.

NOTE: I've tested that `sync mode` and `search` still works.

#471 #482