### PR TITLE
Fix CallGraph FocusController bugs

### DIFF
--- a/dbux-graph-client/src/graph/controllers/FocusController.js
+++ b/dbux-graph-client/src/graph/controllers/FocusController.js
@@ -91,7 +91,7 @@ export default class FocusController extends ClientComponentEndpoint {
 
     let nodeBounds = targetDOM.getBoundingClientRect();
     if (!nodeBounds.height && !nodeBounds.width) {
-      this.logger.error('Trying to slide to unrevealed DOM:', targetDOM, JSON.stringify(nodeBounds));
+      this.logger.error(`Trying to slide to unrevealed DOM: ${targetDOM.outerHTML}, ${JSON.stringify(nodeBounds)}`);
       return;
     }
 

--- a/dbux-graph-host/src/graph/GraphDocument.js
+++ b/dbux-graph-host/src/graph/GraphDocument.js
@@ -20,7 +20,7 @@ class GraphDocument extends HostComponentEndpoint {
     // register event listeners
     this.addDisposable(
       allApplications.selection.onApplicationsChanged(() => {
-        this.graphRoot.refresh();
+        this.graphRoot.updateRunNodes();
       })
     );
   }

--- a/dbux-graph-host/src/graph/GraphRoot.js
+++ b/dbux-graph-host/src/graph/GraphRoot.js
@@ -79,10 +79,10 @@ class GraphRoot extends HostComponentEndpoint {
     this.children.createComponent('HiddenBeforeNode');
     this.children.createComponent('HiddenAfterNode');
 
-    this.refresh();
+    this.updateRunNodes();
   }
 
-  handleRefresh() {
+  updateRunNodes() {
     // oldApps
     const oldAppIds = new Set(this.runNodesById.getApplicationIds());
     const newAppIds = new Set(allApplications.selection.getAll().map(app => app.applicationId));
@@ -263,7 +263,7 @@ class GraphRoot extends HostComponentEndpoint {
 
     while (!(currentNode = this.contextNodesByContext.get(currentContext))) {
       if (!currentContext) {
-        this.logger.warn(`RootContextNode does not exist, contextQueue=${contextQueue}`);
+        this.logger.warn(`RootContextNode does not exist, contextQueue=${contextQueue.map(x => x?.contextId)}`);
         return null;
       }
       contextQueue.push(currentContext);
@@ -298,7 +298,7 @@ class GraphRoot extends HostComponentEndpoint {
       node = this.buildContextNode(context);
     }
 
-    await node.waitForInit();
+    await node?.waitForInit();
 
     return node;
   }

--- a/dbux-graph-host/src/graph/controllers/FocusController.js
+++ b/dbux-graph-host/src/graph/controllers/FocusController.js
@@ -1,5 +1,6 @@
 import NanoEvents from 'nanoevents';
 import { newLogger } from '@dbux/common/src/log/logger';
+import sleep from '@dbux/common/src/util/sleep';
 import traceSelection from '@dbux/data/src/traceSelection';
 import HostComponentEndpoint from '../../componentLib/HostComponentEndpoint';
 
@@ -44,6 +45,7 @@ export default class FocusController extends HostComponentEndpoint {
     try {
       const trace = traceSelection.selected;
       await this.waitForInit();
+      await sleep(100);
       
       let contextNode;
       if (trace) {

--- a/dbux-graph-host/src/graph/controllers/FocusController.js
+++ b/dbux-graph-host/src/graph/controllers/FocusController.js
@@ -45,7 +45,6 @@ export default class FocusController extends HostComponentEndpoint {
     try {
       const trace = traceSelection.selected;
       await this.waitForInit();
-      await sleep(100);
       
       let contextNode;
       if (trace) {

--- a/dbux-graph-host/src/graph/controllers/HiddenNodeManager.js
+++ b/dbux-graph-host/src/graph/controllers/HiddenNodeManager.js
@@ -14,9 +14,8 @@ export default class HiddenNodeManager extends HostComponentEndpoint {
 
   update() {
     for (const runNode of this.getAllRunNode()) {
-      const { applicationId, runId } = runNode.state;
       const visible = this.shouldBeVisible(runNode);
-      this._setVisible(applicationId, runId, visible);
+      this._setVisible(runNode, visible);
     }
     this._notifyStateChanged();
     this._notifyHiddenCountChanged();
@@ -62,8 +61,8 @@ export default class HiddenNodeManager extends HostComponentEndpoint {
   }
 
   /**
- * @param {RunNode} runNode 
- */
+   * @param {RunNode} runNode 
+   */
   getHiddenNodeHidingThis(runNode) {
     const { hideBefore, hideAfter } = this.state;
     if (hideBefore && runNode.state.createdAt < hideBefore) {
@@ -79,8 +78,7 @@ export default class HiddenNodeManager extends HostComponentEndpoint {
   // private
   // ###########################################################################
 
-  _setVisible(applicationId, runId, visible) {
-    const runNode = this.owner.getRunNodeById(applicationId, runId);
+  _setVisible(runNode, visible) {
     runNode.setState({ visible });
   }
 

--- a/dbux-graph-host/src/graph/controllers/HiddenNodeManager.js
+++ b/dbux-graph-host/src/graph/controllers/HiddenNodeManager.js
@@ -79,7 +79,9 @@ export default class HiddenNodeManager extends HostComponentEndpoint {
   // ###########################################################################
 
   _setVisible(runNode, visible) {
-    runNode.setState({ visible });
+    if (runNode.state.visible !== visible) {
+      runNode.setState({ visible });
+    }
   }
 
   // ###########################################################################
@@ -112,9 +114,10 @@ export default class HiddenNodeManager extends HostComponentEndpoint {
     }
 
     // remove hideBefore state if nothing is hidden e.g. while deselect hiddenNode
-    if (!hideBeforeCount) {
-      this.hideBefore(false);
-    }
+    // NOTE: temporarily removed since this may calls setState in during update
+    // if (hideBefore && !hideBeforeCount) {
+    //   this.hideBefore(false);
+    // }
 
     this._emitter.emit('countChanged', {
       hideBeforeCount,


### PR DESCRIPTION
## Note

There is always a problem that `FocusController` tries to `focus` on some node right after we set the nodes' state. And yet we don't have a proper way(a Promise) to check if the DOM element is revealed. Thus, adding `await sleep(100)` before `focus` is a simple hackfix, even though **it might be a bad idea**.

Btw, the first problem "Cannot hide/unhide nodes anymore" is a side effect of this. I used to log a DOM element in the error logger of `FocusController`, which leads to an error `Uncaught DOMException: Failed to execute 'postMessage' on 'Window': A DOMDivElement could not be cloned` and breaks the `postMessage`.
Maybe it's a good practice to ensure parameters passing into log functions are strings.

#485 