### PR TITLE
Allow selecting individual DataNode & add setCallExpressionResultInputs

### DIFF
--- a/dbux-code/src/dataFlowView/ChildDataNode.js
+++ b/dbux-code/src/dataFlowView/ChildDataNode.js
@@ -1,0 +1,14 @@
+import allApplications from '@dbux/data/src/applications/allApplications';
+import DataNode from './DataNode';
+
+export default class ChildDataNode extends DataNode {
+  static makeLabel(trace, parent, props) {
+    const dp = allApplications.getById(trace.applicationId).dataProvider;
+    const node = dp.collections.dataNodes.getById(props.nodeId);
+    return `[${node.varAccess?.prop}]`;
+  }
+
+  canHaveChildren() {
+    return false;
+  }
+}

--- a/dbux-code/src/dataFlowView/DataNode.js
+++ b/dbux-code/src/dataFlowView/DataNode.js
@@ -1,8 +1,34 @@
+import EmptyArray from '@dbux/common/src/util/EmptyArray';
+import allApplications from '@dbux/data/src/applications/allApplications';
+import traceSelection from '@dbux/data/src/traceSelection';
 import TraceNode from '../traceDetailsView/nodes/TraceNode';
 
+/**
+ * Besides a `Trace`, this node also has a `nodeId` to specify one of it's dataNodes.
+ * @property {number} nodeId
+ */
 export default class DataNode extends TraceNode {
   get clickUserActionType() {
     // TODO: add a new action type?
-    return UserActionType.TDTraceUse;
+    return null;
+  }
+
+  get dataNode() {
+    return this.entry
+  }
+  
+  makeIconPath() {
+    return (traceSelection.isSelected(this.trace) && traceSelection.nodeId === this.nodeId) ? 'play.svg' : ' ';
+  }
+
+  handleClick() {
+    traceSelection.selectTrace(this.trace, 'TraceNode', this.nodeId);
+    console.log(`Selecting trace#${this.trace.traceId}, node#${this.nodeId}`);
+  }
+
+  getTraceDataNodes() {
+    const { applicationId, traceId } = this.trace;
+    const dp = allApplications.getById(applicationId).dataProvider;
+    return dp.indexes.dataNodes.byTrace.get(traceId) || EmptyArray;
   }
 }

--- a/dbux-code/src/dataFlowView/ParentDataNode.js
+++ b/dbux-code/src/dataFlowView/ParentDataNode.js
@@ -1,0 +1,17 @@
+import ChildDataNode from './ChildDataNode';
+import DataNode from './DataNode';
+
+/**
+ * @property {number} nodeId
+ */
+export default class ParentDataNode extends DataNode {
+  canHaveChildren() {
+    return this.getTraceDataNodes().length > 1;
+  }
+
+  buildChildren() {
+    const { nodeId } = this;
+    const dataNodes = this.getTraceDataNodes().filter(node => node.nodeId !== nodeId);
+    return dataNodes.map(node => this.treeNodeProvider.buildNode(ChildDataNode, this.trace, this, { nodeId: node.nodeId }));
+  }
+}

--- a/dbux-code/src/traceDetailsView/TraceDetailsNodeProvider.js
+++ b/dbux-code/src/traceDetailsView/TraceDetailsNodeProvider.js
@@ -21,11 +21,10 @@ export default class TraceDetailsDataProvider extends BaseTreeViewNodeProvider {
 
     if (traceSelection.selected) {
       const trace = traceSelection.selected;
-      const nodeId = traceSelection.nodeId;
 
       roots.push(
         this.buildSelectedTraceNode(trace),
-        ...this.buildTraceDetailNodes(trace, nodeId, null)
+        ...this.buildTraceDetailNodes(trace, null)
       );
     }
     else {
@@ -36,13 +35,13 @@ export default class TraceDetailsDataProvider extends BaseTreeViewNodeProvider {
     return roots;
   }
 
-  buildTraceDetailNodes(trace, nodeId, parent) {
+  buildTraceDetailNodes(trace, parent) {
     const nodes = [
       // navigation node
       this.buildNavigationNode(trace, parent),
 
       // other detail nodes
-      ...this.buildDetailNodes(trace, nodeId, parent, DetailNodeClasses)
+      ...this.buildDetailNodes(trace, parent, DetailNodeClasses)
     ].filter(node => !!node);
 
     return nodes;
@@ -52,13 +51,13 @@ export default class TraceDetailsDataProvider extends BaseTreeViewNodeProvider {
   // Detail nodes
   // ###########################################################################
 
-  buildDetailNodes(trace, nodeId, parent, NodeClasses) {
+  buildDetailNodes(trace, parent, NodeClasses) {
     return NodeClasses
-      .map(NodeClass => this.maybeBuildTraceDetailNode(NodeClass, trace, parent, { nodeId }))
+      .map(NodeClass => this.maybeBuildTraceDetailNode(NodeClass, trace, parent))
       .filter(node => !!node);
   }
 
-  maybeBuildTraceDetailNode(NodeClass, trace, parent, { nodeId }) {
+  maybeBuildTraceDetailNode(NodeClass, trace, parent) {
     const detail = NodeClass.makeTraceDetail(trace, parent);
     const props = NodeClass.makeProperties?.(trace, parent, detail) || EmptyObject;
     if (!detail) {
@@ -66,7 +65,6 @@ export default class TraceDetailsDataProvider extends BaseTreeViewNodeProvider {
     }
     const treeItemProps = {
       trace,
-      nodeId,
       ...props
     };
     return this.buildNode(NodeClass, detail, parent, treeItemProps);

--- a/dbux-code/src/traceDetailsView/nodes/TraceNode.js
+++ b/dbux-code/src/traceDetailsView/nodes/TraceNode.js
@@ -16,6 +16,9 @@ export default class TraceNode extends BaseTreeViewNode {
     return makeTraceLabel(trace);
   }
 
+  /**
+   * @type {Trace}
+   */
   get trace() {
     return this.entry;
   }
@@ -33,6 +36,6 @@ export default class TraceNode extends BaseTreeViewNode {
   }
 
   handleClick() {
-    traceSelection.selectTrace(this.trace, 'TraceNode', this.nodeId );
+    traceSelection.selectTrace(this.trace, 'TraceNode');
   }
 }

--- a/dbux-code/src/traceDetailsView/nodes/traceDetailNodes.js
+++ b/dbux-code/src/traceDetailsView/nodes/traceDetailNodes.js
@@ -15,7 +15,6 @@ import { InfoTDNode, ContextTDNode, TraceTypeTDNode } from './traceInfoNodes';
 
 /**
  * @property {Trace} trace
- * @property {number} nodeId
  */
 export class TraceDetailNode extends BaseTreeViewNode {
 }
@@ -46,7 +45,8 @@ export class DebugTDNode extends TraceDetailNode {
   // }
 
   buildChildren() {
-    const { trace, nodeId } = this;
+    const { trace } = this;
+    const { nodeId } = trace;
 
     const application = allApplications.getApplication(trace.applicationId);
     const { dataProvider } = application;
@@ -63,7 +63,7 @@ export class DebugTDNode extends TraceDetailNode {
     const { staticContextId } = context;
     const staticContext = dataProvider.collections.staticContexts.getById(staticContextId);
     const dataNodes = dataProvider.util.getDataNodesOfTrace(traceId);
-    
+
     let dataNode;
     if (nodeId) {
       dataNode = dataProvider.collections.dataNodes.getById(nodeId);
@@ -86,7 +86,7 @@ export class DebugTDNode extends TraceDetailNode {
     ];
 
     const children = [
-      ...this.treeNodeProvider.buildDetailNodes(this.trace, this.nodeId, this, [
+      ...this.treeNodeProvider.buildDetailNodes(this.trace, this, [
         TraceTypeTDNode,
         ContextTDNode,
       ]),

--- a/dbux-code/src/traceDetailsView/nodes/traceInfoNodes.js
+++ b/dbux-code/src/traceDetailsView/nodes/traceInfoNodes.js
@@ -99,7 +99,7 @@ export class InfoTDNode extends BaseTreeViewNode {
   }
 
   buildChildren() {
-    return this.treeNodeProvider.buildDetailNodes(this.trace, this.nodeId, this, [
+    return this.treeNodeProvider.buildDetailNodes(this.trace, this, [
       ApplicationTDNode,
       ContextTDNode,
       TraceTypeTDNode,

--- a/dbux-data/src/RuntimeDataProvider.js
+++ b/dbux-data/src/RuntimeDataProvider.js
@@ -599,29 +599,10 @@ class ValueRefCollection extends Collection {
       }
       else {
         switch (category) {
-          case ValueTypeCategory.Array: {
-            value = [];
-            for (let i = 0; i < entry.serialized.length; ++i) {
-              const [childId, childValue] = entry.serialized[i];
-              if (childId) {
-                const childEntry = this.getById(childId);
-                if (!childEntry) {
-                  value[i] = '(Dbux: lookup failed)';
-                  this.logger.warn(`Could not lookup object property "${i}" (id = "${childId}"): ${JSON.stringify(childEntry.serialized)}`);
-                }
-                else {
-                  value[i] = this._deserializeValue(childEntry);
-                }
-              }
-              else {
-                value[i] = childValue;
-              }
-            }
-            break;
-          }
+          case ValueTypeCategory.Array: 
           case ValueTypeCategory.Object: {
             value = {};
-            for (const [key, childId, childValue] of entry.serialized) {
+            for (const [key, [childId, childValue]] of Object.entries(entry.serialized)) {
               if (childId) {
                 const childEntry = this.getById(childId);
                 if (!childEntry) {

--- a/dbux-data/src/RuntimeDataProvider.js
+++ b/dbux-data/src/RuntimeDataProvider.js
@@ -148,6 +148,7 @@ class ExecutionContextCollection extends Collection {
    */
   postIndexRaw(entries) {
     this.errorWrapMethod('setParamInputs', entries);
+    this.errorWrapMethod('setCallExpressionResultInputs', entries);
   }
 
   setParamInputs(contexts) {
@@ -155,7 +156,7 @@ class ExecutionContextCollection extends Collection {
     for (const { contextId } of contexts) {
       const paramTraces = util.getTracesOfContextAndType(contextId, TraceType.Param);
       if (!paramTraces.length) {
-        // function has no no parameters -> nothing to do
+        // function has no parameters -> nothing to do
         continue;
       }
       const bceTrace = util.getCallerTraceOfContext(contextId); // BCE
@@ -192,6 +193,33 @@ class ExecutionContextCollection extends Collection {
       }
 
       // TODO: `RestElement`
+    }
+  }
+
+  setCallExpressionResultInputs(contexts) {
+    const { dp, dp: { util } } = this;
+    for (const { contextId } of contexts) {
+      const returnTraces = util.getTracesOfContextAndType(contextId, TraceType.ReturnArgument);
+      if (!returnTraces.length) {
+        // function has no return value -> nothing to do
+        continue;
+      }
+      else if (returnTraces.length > 1) {
+        this.logger.error(`Found context containing more than one CER trace. contextId: ${contextId}, CER traceIds: [${returnTraces}]`);
+        continue;
+      }
+
+      const returnTrace = returnTraces[0];
+
+      const bceTrace = util.getCallerTraceOfContext(contextId); // BCE
+      if (!bceTrace) {
+        // no BCE -> must be root context (not called by us) -> nothing to do
+        continue;
+      }
+      const cerTrace = dp.collections.traces.getById(bceTrace.resultId);
+
+      const cerDataNode = dp.collections.dataNodes.getById(cerTrace.nodeId);
+      cerDataNode.inputs = [returnTrace.nodeId];
     }
   }
 
@@ -255,9 +283,19 @@ class TraceCollection extends Collection {
    */
   postAddRaw(traces) {
     // build dynamic call expression tree
+    this.errorWrapMethod('registerResultId', traces);
     this.errorWrapMethod('resolveCodeChunks', traces);
     this.errorWrapMethod('resolveCallIds', traces);
     this.errorWrapMethod('resolveErrorTraces', traces);
+  }
+
+  registerResultId(traces) {
+    for (const { traceId, resultCallId } of traces) {
+      if (resultCallId) {
+        const bceTrace = this.dp.collections.traces.getById(resultCallId);
+        bceTrace.resultId = traceId;
+      }
+    }
   }
 
   resolveCodeChunks(traces) {
@@ -424,7 +462,7 @@ class DataNodeCollection extends Collection {
           this.logger.warn(`[getValueId] Cannot find valueId for empty inputs.\n    trace: ${this.dp.util.makeTraceInfo(traceId)}\n    dataNode: ${JSON.stringify(dataNode)}`);
         }
         else {
-          return null;
+          return traceId;
         }
       }
     }

--- a/dbux-data/src/RuntimeDataProvider.js
+++ b/dbux-data/src/RuntimeDataProvider.js
@@ -457,13 +457,11 @@ class DataNodeCollection extends Collection {
           // NOTE: currently, last in `byAccessId` index is actually "the last before this one", since we are still resolving the index.
           return lastNode.valueId;
         }
-        else if (!TraceType.is.CallExpressionResult(traceType)) {
-          // eslint-disable-next-line max-len
-          this.logger.warn(`[getValueId] Cannot find valueId for empty inputs.\n    trace: ${this.dp.util.makeTraceInfo(traceId)}\n    dataNode: ${JSON.stringify(dataNode)}`);
-        }
         else {
-          return traceId;
+          // eslint-disable-next-line max-len
+          // this.logger.warn(`[getValueId] Cannot find valueId for empty inputs.\n    trace: ${this.dp.util.makeTraceInfo(traceId)}\n    dataNode: ${JSON.stringify(dataNode)}`);
         }
+        return traceId;
       }
     }
     return dataNode.valueId;

--- a/dbux-data/src/traceSelection/index.js
+++ b/dbux-data/src/traceSelection/index.js
@@ -11,6 +11,10 @@ export class TraceSelection {
   }
 
   selectTrace(trace, sender = null, nodeId = null) {
+    if (!nodeId) {
+      // select its node by default
+      nodeId = trace.nodeId || null;
+    }
     this._setSelectTrace(trace, nodeId);
     this._emitSelectionChangedEvent(sender, nodeId);
   }

--- a/dbux-runtime/src/data/valueCollection.js
+++ b/dbux-runtime/src/data/valueCollection.js
@@ -312,7 +312,7 @@ class ValueCollection extends Collection {
   _pushObjectProp(depth, prop, valueRef, value, serialized) {
     Verbose > 1 && this._logValue(`${' '.repeat(depth)}[${prop}]`, valueRef, value);
 
-    serialized.push([prop, valueRef && valueRef.refId, !valueRef && value]);
+    serialized[prop] = [valueRef && valueRef.refId, !valueRef && value];
   }
 
   /**
@@ -425,7 +425,7 @@ class ValueCollection extends Collection {
             }
 
             // start serializing
-            serialized = [];
+            serialized = {};
 
             const builtInSerializer = value.constructor ? builtInTypeSerializers.get(value.constructor) : null;
             if (builtInSerializer) {

--- a/samples/__samplesInput__/slicing/returns1.js
+++ b/samples/__samplesInput__/slicing/returns1.js
@@ -1,0 +1,14 @@
+function a() {
+  return 1;
+}
+
+function b() {
+  return;
+}
+
+function c() {
+}
+
+a();
+b();
+c();

--- a/samples/__samplesInput__/slicing/values1.js
+++ b/samples/__samplesInput__/slicing/values1.js
@@ -1,0 +1,9 @@
+const u = undefined;
+const o = {};
+const n = null;
+const N = NaN;
+
+const one = 1;
+const second_one = 1;
+
+console.log(u, o, n, N, one)


### PR DESCRIPTION
- add `ChildDataNode` in `DataFlowView`
- remove `nodeId` in `TDView`
- add `setCallExpressionResultInputs`
- fix no input params have valueId `undefined`
- auto select node on `traceSelection`
- use object to store value for `ObjectCategory`

#521 