### PR TITLE
fix async graph

### DIFF
--- a/dbux-data/src/dataProviderImpl.js
+++ b/dbux-data/src/dataProviderImpl.js
@@ -38,14 +38,15 @@ import ContextsByTypeIndex from './impl/indexes/ContextsByTypeIndex';
 import ProgramIdByFilePathQuery from './impl/queries/ProgramIdByFilePathQuery';
 import ProgramFilePathByTraceIdQuery from './impl/queries/ProgramFilePathByTraceIdQuery';
 import StatsByContextQuery from './impl/queries/StatsByContextQuery';
-import AsyncEventsToIndex from './impl/indexes/AsyncEventsToIndex';
 import DataNodesByTraceIndex from './impl/indexes/DataNodesByTraceIndex';
 import DataNodesByAccessIdIndex from './impl/indexes/DataNodesByAccessIdIndex';
 import DataNodesByValueIdIndex from './impl/indexes/DataNodesByValueIdIndex';
 import DataNodesByRefIdIndex from './impl/indexes/DataNodesByRefIdIndex';
 import DataNodesByObjectRefIdIndex from './impl/indexes/DataNodesByObjectRefIdIndex';
+import AsyncEventsToIndex from './impl/indexes/AsyncEventsToIndex';
 import AsyncEventsFromIndex from './impl/indexes/AsyncEventsFromIndex';
 import AsyncNodesByRootIndex from './impl/indexes/AsyncNodesByRootIndex';
+import AsyncNodesByThreadIndex from './impl/indexes/AsyncNodesByThreadIndex';
 
 
 export function newDataProvider(application) {
@@ -103,6 +104,7 @@ export function newDataProvider(application) {
   dataProvider.addIndex(new AsyncEventsFromIndex());
   dataProvider.addIndex(new AsyncEventsToIndex());
   dataProvider.addIndex(new AsyncNodesByRootIndex());
+  dataProvider.addIndex(new AsyncNodesByThreadIndex());
 
   // complex indexes (that have dependencies)
   // NOTE: we are currently solving index dependencies by simply adding depdendents after dependees

--- a/dbux-data/src/dataProviderUtil.js
+++ b/dbux-data/src/dataProviderUtil.js
@@ -69,7 +69,6 @@ export default {
 
   /** @param {DataProvider} dp */
   getRootContextIdByContextId(dp, contextId) {
-    // TODO: use `this.getFirstContextOfRun(runId)` instead
     const { executionContexts } = dp.collections;
     let lastContextId = contextId;
     let parentContextId;

--- a/dbux-data/src/impl/indexes/AsyncNodesByThreadIndex.js
+++ b/dbux-data/src/impl/indexes/AsyncNodesByThreadIndex.js
@@ -1,0 +1,20 @@
+import AsyncNode from '@dbux/common/src/core/data/AsyncNode';
+import CollectionIndex from '../../indexes/CollectionIndex';
+import RuntimeDataProvider from '../../RuntimeDataProvider';
+
+
+
+/** @extends {CollectionIndex<AsyncNode>} */
+export default class AsyncNodesByThreadIndex extends CollectionIndex {
+  constructor() {
+    super('asyncNodes', 'byThread');
+  }
+
+  /** 
+   * @param {RuntimeDataProvider} dp
+   * @param {AsyncNode} asyncNode
+   */
+  makeKey(dp, { threadId }) {
+    return threadId;
+  }
+}

--- a/dbux-data/src/indexes/CollectionIndex.js
+++ b/dbux-data/src/indexes/CollectionIndex.js
@@ -108,6 +108,11 @@ class ContainerMethods {
   }
 
   // eslint-disable-next-line no-unused-vars
+  getUniqueInContainer(container) {
+    throw new Error('abstract method not implemented');
+  }
+
+  // eslint-disable-next-line no-unused-vars
   addEntry(container, entry) {
     throw new Error('abstract method not implemented');
   }
@@ -124,6 +129,15 @@ class ArrayContainerMethods extends ContainerMethods {
 
   getLastInContainter(container) {
     return container?.[container.length - 1];
+  }
+
+  getUniqueInContainer(container) {
+    if (container?.length === 1) {
+      return container[0];
+    }
+    else {
+      return null;
+    }
   }
 
   addEntry(container, entry) {
@@ -144,6 +158,15 @@ class SetContainerMethods extends ContainerMethods {
   getLastInContainter(container) {
     this.index.logger.warn(`Trying to get last item in a set container`);
     return container.values().next().value;
+  }
+
+  getUniqueInContainer(container) {
+    if (container?.size === 1) {
+      return container.values().next().value;
+    }
+    else {
+      return null;
+    }
   }
 
   addEntry(container, entry) {
@@ -214,6 +237,15 @@ export default class CollectionIndex {
   getLast(key) {
     const container = this.get(key);
     return this._containerMethods.getLastInContainter(container) || null;
+  }
+
+  getUnique(key) {
+    const container = this.get(key);
+    const entry = this._containerMethods.getUniqueInContainer(container);
+    if (key && !entry) {
+      this.logger.error(`Cannot getUnique entry for key: ${key}`);
+    }
+    return entry;
   }
 
   getAll() {

--- a/dbux-graph-client/src/graph/controllers/FocusController.js
+++ b/dbux-graph-client/src/graph/controllers/FocusController.js
@@ -158,11 +158,9 @@ export default class FocusController extends ClientComponentEndpoint {
     }
   }
 
-  getAsyncNodeEl({ applicationId, runId, threadId }) {
+  getAsyncNodeEl(asyncNode) {
     const data = {
-      'application-id': applicationId,
-      'run-id': runId,
-      'thread-id': threadId,
+      'async-node-id': asyncNode.asyncNodeId,
     };
     const dataSelector = Object.entries(data).map(([key, val]) => `[data-${key}="${val || ''}"]`).join('');
     const selector = `.async-node${dataSelector}`;
@@ -175,30 +173,30 @@ export default class FocusController extends ClientComponentEndpoint {
      * @param {{applicationId: number, runId: number, threadId: number}} selector 
      * @param {boolean} ignoreFailed 
      */
-    focusAsyncNode: (selector, ignoreFailed = false) => {
-      const asyncNodeEl = this.getAsyncNodeEl(selector);
-      if (!asyncNodeEl) {
-        !ignoreFailed && this.logger.error(`Cannot find asyncNode with data ${JSON.stringify(selector)} when trying to focus`);
-      }
-      else {
+    focusAsyncNode: (asyncNode, ignoreFailed = false) => {
+      const asyncNodeEl = this.getAsyncNodeEl(asyncNode);
+      if (asyncNodeEl) {
         this.slide(asyncNodeEl);
+      }
+      else if (!ignoreFailed) {
+        this.logger.error(`Cannot find DOM of asyncNode: ${JSON.stringify(asyncNode)} when trying to focus`);
       }
     },
     /**
      * @param {{applicationId: number, runId: number, threadId: number}} selector 
      * @param {boolean} ignoreFailed 
      */
-    selectAsyncNode: (selector, ignoreFailed = false) => {
+    selectAsyncNode: (asyncNode, ignoreFailed = false) => {
       document.querySelectorAll('.async-node-selected').forEach(node => {
         node.classList.remove('async-node-selected');
       });
-      if (selector) {
-        const asyncNodeEl = this.getAsyncNodeEl(selector);
-        if (!asyncNodeEl) {
-          !ignoreFailed && this.logger.error(`Cannot find asyncNode with data ${JSON.stringify(selector)} when trying to select`);
-        }
-        else {
+      if (asyncNode) {
+        const asyncNodeEl = this.getAsyncNodeEl(asyncNode);
+        if (asyncNodeEl) {
           asyncNodeEl.classList.add('async-node-selected');
+        }
+        else if (!ignoreFailed) {
+          this.logger.error(`Cannot find DOM of asyncNode: ${JSON.stringify(asyncNode)} when trying to select`);
         }
       }
     }

--- a/dbux-graph-client/src/graph/styles.css
+++ b/dbux-graph-client/src/graph/styles.css
@@ -220,7 +220,7 @@ html, body {
   min-height: 2.8em;
 }
 
-.async-node:hover:not([data-context-id=""]) {
+.async-node:hover:not([data-async-node-id=""]) {
   border: 1px solid white;
   cursor: pointer;
 }

--- a/dbux-graph-host/src/graph/asyncGraph/ThreadColumn.js
+++ b/dbux-graph-host/src/graph/asyncGraph/ThreadColumn.js
@@ -7,10 +7,10 @@ const { log, debug, warn, error: logError } = newLogger('ThreadColumn');
 
 class ThreadColumn extends HostComponentEndpoint {
   public = {
-    gotoContext(applicationId, contextId) {
-      const app = allApplications.getById(applicationId);
-      const firstTrace = app.dataProvider.indexes.traces.byContext.getFirst(contextId);
-
+    gotoAsyncNode(applicationId, asyncNodeId) {
+      const dp = allApplications.getById(applicationId).dataProvider;
+      const asyncNode = dp.collections.asyncNodes.getById(asyncNodeId);
+      const firstTrace = dp.indexes.traces.byContext.getFirst(asyncNode.rootContextId);
       if (firstTrace) {
         traceSelection.selectTrace(firstTrace);
       }

--- a/dbux-graph-host/src/graph/controllers/FocusController.js
+++ b/dbux-graph-host/src/graph/controllers/FocusController.js
@@ -47,22 +47,22 @@ export default class FocusController extends HostComponentEndpoint {
       await this.waitForInit();
       if (this.context.graphDocument.asyncGraphMode) {
         // goto async node of trace
-        let applicationId, contextId, runId, threadId;
+        let asyncNode;
         if (trace) {
-          ({ applicationId, contextId } = trace);
+          const { applicationId } = trace;
           const dp = allApplications.getById(applicationId).dataProvider;
-          const context = dp.collections.executionContexts.getById(contextId);
-          ({ runId, threadId } = context);
+          const { rootContextId } = trace;
+          asyncNode = dp.indexes.asyncNodes.byRoot.getFirst(rootContextId);
           if (this.syncMode) {
-            await this.remote.focusAsyncNode({ applicationId, runId, threadId }, ignoreFailed);
+            await this.remote.focusAsyncNode(asyncNode, ignoreFailed);
           }
         }
         else {
           this.clearFocus();
         }
 
-        if (applicationId && runId && threadId) {
-          this.remote.selectAsyncNode({ applicationId, runId, threadId }, ignoreFailed);
+        if (asyncNode) {
+          this.remote.selectAsyncNode(asyncNode, ignoreFailed);
         }
         else {
           this.remote.selectAsyncNode(null);


### PR DESCRIPTION
Also, add `getUnique` to `CollectionIndex` which logs error when result is not unique.
Usage:
```js
/**
 * NOTE: The `AsyncNode` of a `rootContextId` is unique.
 */
dp.indexes.asyncNodes.byRoot.getUnique(rootContextId);
```

#452