### PR TITLE
Fix VSCode intellisense

### DIFF
--- a/dbux-babel-plugin/jsconfig.json
+++ b/dbux-babel-plugin/jsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": [
         "../dbux-common/*"

--- a/dbux-cli/jsconfig.json
+++ b/dbux-cli/jsconfig.json
@@ -7,6 +7,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": [
         "../dbux-common/*"

--- a/dbux-code/jsconfig.json
+++ b/dbux-code/jsconfig.json
@@ -7,6 +7,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": [
         "../dbux-common/*"

--- a/dbux-common-node/jsconfig.json
+++ b/dbux-common-node/jsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": [
         "../dbux-common/*"

--- a/dbux-data/jsconfig.json
+++ b/dbux-data/jsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": ["../dbux-common/*"],
       "@dbux/common-node/*": ["../dbux-common-node/*"],

--- a/dbux-graph-common/jsconfig.json
+++ b/dbux-graph-common/jsconfig.json
@@ -3,6 +3,7 @@
     "module": "esnext",
     "target": "esnext",
     "checkJs": false,  /* Typecheck .js files. */
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": ["../dbux-common/*"]
     }

--- a/dbux-runtime/jsconfig.json
+++ b/dbux-runtime/jsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": ["../dbux-common/*"],
     }

--- a/dbux-server/jsconfig.json
+++ b/dbux-server/jsconfig.json
@@ -7,6 +7,7 @@
     "lib": [
       "es6"
     ],
+    "baseUrl": "./",
     "paths": {
       "@dbux/common/*": [
         "../dbux-common/*"


### PR DESCRIPTION
NOTE: VSCode intellisense needs `baseUrl` to make path alias works