### PR TITLE
fixes of #561

### DIFF
--- a/dbux-code/package.json
+++ b/dbux-code/package.json
@@ -553,6 +553,14 @@
         }
       },
       {
+        "command": "dbuxProjectView.node.exerciseCleanup",
+        "title": "Clean Up",
+        "icon": {
+          "light": "resources/light/clear.svg",
+          "dark": "resources/dark/clear.svg"
+        }
+      },
+      {
         "command": "dbuxProjectView.node.stopProject",
         "title": "Stop project",
         "icon": {
@@ -820,6 +828,11 @@
           "group": "inline@0"
         },
         {
+          "command": "dbuxProjectView.node.exerciseCleanup",
+          "when": "viewItem =~ /dbuxProjectView\\.exerciseNode/ && !dbuxProjectView.context.isBusy",
+          "group": "inline@2"
+        },
+        {
           "command": "dbuxProjectView.node.startPractice",
           "when": "viewItem =~ /dbuxProjectView\\.exerciseNode\\.(None|Done)\\..*/ && !dbuxProjectView.context.isBusy",
           "group": "inline@20"
@@ -851,7 +864,7 @@
         },
         {
           "command": "dbuxProjectView.node.showExerciseLog",
-          "when": "viewItem =~ /dbuxProjectView\\.exerciseNode/",
+          "when": "false && viewItem =~ /dbuxProjectView\\.exerciseNode/",
           "group": "inline@8"
         },
         {
@@ -1317,6 +1330,10 @@
         },
         {
           "command": "dbuxProjectView.node.cleanup",
+          "when": "false"
+        },
+        {
+          "command": "dbuxProjectView.node.exerciseCleanup",
           "when": "false"
         },
         {

--- a/dbux-code/src/commands/projectCommands.js
+++ b/dbux-code/src/commands/projectCommands.js
@@ -87,6 +87,10 @@ export function initProjectCommands(extensionContext, projectViewController) {
     return node.cleanUp();
   });
 
+  registerCommand(extensionContext, 'dbuxProjectView.node.exerciseCleanup', (node) => {
+    return node.cleanUp();
+  });
+
   registerCommand(extensionContext, 'dbuxProjectView.node.stopProject', (/* node */) => {
     return projectViewController.manager.runner.cancel();
   });

--- a/dbux-code/src/projectViews/practiceView/ExerciseNode.js
+++ b/dbux-code/src/projectViews/practiceView/ExerciseNode.js
@@ -3,6 +3,7 @@ import ExerciseStatus from '@dbux/projects/src/dataLib/ExerciseStatus';
 import RunStatus from '@dbux/projects/src/projectLib/RunStatus';
 import BaseTreeViewNode from '../../codeUtil/BaseTreeViewNode';
 import { showInformationMessage } from '../../codeUtil/codeModals';
+import cleanUp from './cleanUp';
 
 /** @typedef {import('@dbux/projects/src/projectLib/Exercise').default} Exercise */
 /** @typedef {import('@dbux/projects/src/ProjectsManager').default} ProjectsManager */
@@ -110,5 +111,9 @@ export default class ExerciseNode extends BaseTreeViewNode {
 
   async showExerciseLog() {
     await this.exercise.manager.showExerciseLog(this.exercise);
+  }
+
+  async cleanUp() {
+    await cleanUp(this.treeNodeProvider, this.exercise.project);
   }
 }

--- a/dbux-code/src/projectViews/practiceView/ProjectNode.js
+++ b/dbux-code/src/projectViews/practiceView/ProjectNode.js
@@ -1,9 +1,8 @@
 import Project from '@dbux/projects/src/projectLib/Project';
 import RunStatus from '@dbux/projects/src/projectLib/RunStatus';
 import BaseTreeViewNode from '../../codeUtil/BaseTreeViewNode';
+import cleanUp from './cleanUp';
 import ExerciseNode from './ExerciseNode';
-import { runTaskWithProgressBar } from '../../codeUtil/runTaskWithProgressBar';
-import { showInformationMessage } from '../../codeUtil/codeModals';
 
 /** @typedef {import('@dbux/projects/src/ProjectsManager').default} ProjectsManager */
 
@@ -59,41 +58,6 @@ export default class ProjectNode extends BaseTreeViewNode {
   }
 
   async cleanUp() {
-    const confirmMessage = `How do you want to clean up the project: ${this.project.name}?`;
-    const btnConfig = {
-      "Flush Cache Only": async () => {
-        await runTaskWithProgressBar(async (progress/* , cancelToken */) => {
-          progress.report({ message: 'deleting project folder...' });
-          this.project.deleteCacheFolder();
-        }, {
-          cancellable: false,
-          title: this.project.name,
-        });
-
-        this.treeNodeProvider.refresh();
-        showInformationMessage('Cache flushed successfully.');
-      },
-      "Clear Log Files": async () => {
-        // TODO: better explain this
-        await this.project.clearLog();
-        showInformationMessage('Log files removed successfully.');
-      },
-      "Delete Project (+ Cache)": async () => {
-        const success = await runTaskWithProgressBar(async (progress/* , cancelToken */) => {
-          progress.report({ message: 'deleting project folder...' });
-
-          return await this.project.deleteProjectFolder();
-        }, {
-          cancellable: false,
-          title: this.project.name,
-        });
-
-        if (success) {
-          this.treeNodeProvider.refresh();
-          await showInformationMessage('Project has been deleted successfully.');
-        }
-      }
-    };
-    await showInformationMessage(confirmMessage, btnConfig, { modal: true });
+    await cleanUp(this.treeNodeProvider, this.project);
   }
 }

--- a/dbux-code/src/projectViews/practiceView/cleanUp.js
+++ b/dbux-code/src/projectViews/practiceView/cleanUp.js
@@ -1,0 +1,48 @@
+import { showInformationMessage } from '../../codeUtil/codeModals';
+import { runTaskWithProgressBar } from '../../codeUtil/runTaskWithProgressBar';
+
+/** @typedef {import('@dbux/projects/src/projectLib/Project').default} Project */
+/** @typedef {import('./ProjectNodeProvider').default} ProjectNodeProvider */
+
+/**
+ * @param {ProjectNodeProvider} treeNodeProvider 
+ * @param {Project} project 
+ */
+export default async function cleanUp(treeNodeProvider, project) {
+  const confirmMessage = `How do you want to clean up the project: ${project.name}?`;
+  const btnConfig = {
+    "Flush Cache Only": async () => {
+      await runTaskWithProgressBar(async (progress/* , cancelToken */) => {
+        progress.report({ message: 'deleting project folder...' });
+        project.deleteCacheFolder();
+      }, {
+        cancellable: false,
+        title: project.name,
+      });
+
+      treeNodeProvider.refresh();
+      showInformationMessage('Cache flushed successfully.');
+    },
+    "Clear Log Files": async () => {
+      // TODO: better explain this
+      await project.clearLog();
+      showInformationMessage('Log files removed successfully.');
+    },
+    "Delete Project (+ Cache)": async () => {
+      const success = await runTaskWithProgressBar(async (progress/* , cancelToken */) => {
+        progress.report({ message: 'deleting project folder...' });
+
+        return await project.deleteProjectFolder();
+      }, {
+        cancellable: false,
+        title: project.name,
+      });
+
+      if (success) {
+        treeNodeProvider.refresh();
+        await showInformationMessage('Project has been deleted successfully.');
+      }
+    }
+  };
+  await showInformationMessage(confirmMessage, btnConfig, { modal: true });
+}

--- a/dbux-graph-host/src/graph/SyncGraphBase.js
+++ b/dbux-graph-host/src/graph/SyncGraphBase.js
@@ -114,7 +114,9 @@ class SyncGraphBase extends GraphBase {
 
     this.contextNodesByContext.set(context, contextNode);
     contextNode.addDisposable(() => {
-      this.contextNodesByContext.delete(context);
+      if (this.contextNodesByContext.get(context) === contextNode) {
+        this.contextNodesByContext.delete(context);
+      }
     });
 
     return contextNode;
@@ -125,7 +127,8 @@ class SyncGraphBase extends GraphBase {
     // NOTE: sometimes, `contextNode` does not exist, for some reason
     //    -> might be because `this.roots` contains roots that are not actually displayed
     contextNode?.dispose();
-    this.contextNodesByContext.delete(context);
+    // register disposable on add instead
+    // this.contextNodesByContext.delete(context);
   }
 
   buildContextNodeChildren(contextNode) {

--- a/dbux-projects/assets/chapterLists/list1.js
+++ b/dbux-projects/assets/chapterLists/list1.js
@@ -29,6 +29,7 @@ module.exports = [
     id: 3,
     name: 'TODO MVC',
     exercises: [
+      'todomvc-es6#1',
       'todomvc-es6#2',
       'todomvc-es6#3',
       'todomvc-es6#4',

--- a/dbux-projects/src/projectLib/ExerciseRunner.js
+++ b/dbux-projects/src/projectLib/ExerciseRunner.js
@@ -260,7 +260,7 @@ export default class ExerciseRunner {
         const successful = await this.manager.externals.openWebsite(website);
         if (successful) {
           // NOTE: this used to work fine, but now, the promise never resolves. Maybe a recent VSCode bug.
-          // await waitForNewAppPromise;
+          await waitForNewAppPromise;
         }
         else {
           this.logger.warn(`Cannot open website ${website}`);

--- a/dbux-projects/src/projects/todomvc-es6/Project.js
+++ b/dbux-projects/src/projects/todomvc-es6/Project.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import { writeMergePackageJson } from '@dbux/cli/lib/package-util';
 import { pathResolve } from '@dbux/common-node/src/util/pathUtil';
 import WebpackBuilder from '../../buildTools/WebpackBuilder';
 import Exercise from '../../projectLib/Exercise';
@@ -59,6 +60,11 @@ export default class TodomvcEs6Project extends Project {
         }
       }
     });
+  }
+  
+  async beforeInstall() {
+    // remove husky from package.json
+    writeMergePackageJson(this.projectPath, { scripts: undefined });
   }
 
   async afterInstall() {

--- a/dbux-projects/src/projects/todomvc-es6/Project.js
+++ b/dbux-projects/src/projects/todomvc-es6/Project.js
@@ -75,16 +75,17 @@ export default class TodomvcEs6Project extends Project {
    * 
    * @param {Exercise} exercise 
    */
-  decorateExerciseForRun(exercise) {
+  decorateExercise(exercise) {
     // fix relative file paths
     // exercise.mainEntryPoint = this.builder.getEntryOutputPath('bundle', exercise);
-    exercise.mainEntryPoint = pathResolve(this.projectPath, 'src/app.js');
+    exercise.mainEntryPoint = pathResolve(this.srcRoot, 'src/app.js');
     if (exercise.bugLocations) {
       exercise.bugLocations = exercise.bugLocations.map(loc => (loc && {
         ...loc,
         file: this.getAbsoluteFilePath(loc.file)
       }));
     }
+    return exercise;
   }
 
   async runCommand(bug, cfg) {


### PR DESCRIPTION
### CallGraph
- asynchronously dispose client components
- do `AsyncGraph.postUpdate` on refresh

### Practice
- fix practice session not saved for some Exercise
- fix `todomvc-es6` cannot open program entry point
- duplicate `CleanUp` button to `ExerciseNode`
- add base case of `todomvc-es6` to its chapter
- hide `ShowExerciseLog` button

#561