### PR TITLE
`GlobalErrorsNode` related changes

### DIFF
--- a/dbux-code/package.json
+++ b/dbux-code/package.json
@@ -694,6 +694,16 @@
           "command": "dbuxTraceDetailsView.selectTraceAtCursor",
           "when": "dbux.context.activated && dbuxTraceDetailsView.context.hasTracesAtCursor && dbux.context.showNavButton",
           "group": "navigation@11"
+        },
+        {
+          "command": "dbux.showGraphView",
+          "when": "!dbuxWebView.context.dbux-graph.isActive && !dbux.context.isApplicationEmpty",
+          "group": "navigation@1"
+        },
+        {
+          "command": "dbux.hideGraphView",
+          "when": "dbuxWebView.context.dbux-graph.isActive && !dbux.context.isApplicationEmpty",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/dbux-code/package.json
+++ b/dbux-code/package.json
@@ -966,22 +966,22 @@
         },
         {
           "command": "dbux.showGraphView",
-          "when": "view == dbuxTraceDetailsView && !dbuxWebView.context.dbux-graph.isActive",
+          "when": "view =~ /(dbuxTraceDetailsView|dbuxGlobalAnalysisView)/ && !dbuxWebView.context.dbux-graph.isActive",
           "group": "navigation@10"
         },
         {
           "command": "dbux.hideGraphView",
-          "when": "view == dbuxTraceDetailsView && dbuxWebView.context.dbux-graph.isActive",
+          "when": "view =~ /(dbuxTraceDetailsView|dbuxGlobalAnalysisView)/ && dbuxWebView.context.dbux-graph.isActive",
           "group": "navigation@10"
         },
         {
           "command": "dbux.showPathwaysView",
-          "when": "view == dbuxTraceDetailsView && !dbuxWebView.context.dbux-pathways.isActive",
+          "when": "view == dbuxApplicationsView && !dbuxWebView.context.dbux-pathways.isActive",
           "group": "navigation@11"
         },
         {
           "command": "dbux.hidePathwaysView",
-          "when": "view == dbuxTraceDetailsView && dbuxWebView.context.dbux-pathways.isActive",
+          "when": "view == dbuxApplicationsView && dbuxWebView.context.dbux-pathways.isActive",
           "group": "navigation@11"
         },
         {

--- a/dbux-code/src/applicationsView/applicationsViewController.js
+++ b/dbux-code/src/applicationsView/applicationsViewController.js
@@ -35,6 +35,7 @@ class ApplicationsViewController {
 
     // data changed
     allApplications.selection.onApplicationsChanged((apps) => {
+      this.updateApplicationContext();
       this.refreshOnData();
 
       for (const app of apps) {
@@ -47,6 +48,15 @@ class ApplicationsViewController {
     allApplications.onRemoved(this.refreshOnData);
     allApplications.onClear(this.refreshOnData);
     // allApplications.onRestarted(this.refreshOnData);
+  }
+
+  async updateApplicationContext() {
+    try {
+      await commands.executeCommand('setContext', 'dbux.context.isApplicationEmpty', allApplications.length === 0);
+    }
+    catch (err) {
+      logError(err);
+    }
   }
 }
 

--- a/dbux-code/src/globalAnalysisView/ErrorTraceManager.js
+++ b/dbux-code/src/globalAnalysisView/ErrorTraceManager.js
@@ -1,16 +1,21 @@
 import { commands } from 'vscode';
 import allApplications from '@dbux/data/src/applications/allApplications';
 import traceSelection from '@dbux/data/src/traceSelection';
+import EmptyArray from '@dbux/common/src/util/EmptyArray';
+
+/** @typedef {import('@dbux/common/src/types/Trace').default} Trace */
 
 export default class ErrorTraceManager {
   constructor() {
     this._all = [];
     this.index = 0;
+    this._leavesNeedUpdate = false;
   }
 
   refresh() {
     this.index = 0;
     this._all = allApplications.selection.data.collectGlobalStats((dp) => dp.util.getAllErrorTraces());
+    this._leavesNeedUpdate = true;
     this.updateErrorButton();
   }
 
@@ -18,9 +23,19 @@ export default class ErrorTraceManager {
     return this._all[this.index] || null;
   }
 
+  /**
+   * @returns {Trace[]}
+   */
   getLeaves() {
-    // TODO: fix this
-    return this._all;
+    if (this._leavesNeedUpdate) {
+      this._findLeaves();
+      this._leavesNeedUpdate = false;
+    }
+    return Array.from(this._errorsByLeaf.keys());
+  }
+
+  getErrorsByLeaf(leaf) {
+    return this._errorsByLeaf.get(leaf);
   }
 
   getAll() {
@@ -44,6 +59,31 @@ export default class ErrorTraceManager {
     }
     if (trace) {
       traceSelection.selectTrace(trace);
+    }
+  }
+
+  _findLeaves() {
+    const potentialLeaves = new Set(this._all);
+    this._errorsByLeaf = new Map();
+    for (let i = this._all.length - 1; i >= 0; --i) {
+      const trace = this._all[i];
+      const dp = allApplications.getById(trace.applicationId).dataProvider;
+      if (potentialLeaves.has(trace)) {
+        potentialLeaves.delete(trace);
+        const errorsOnStack = [];
+        let currentTrace = dp.util.getCallerOrSchedulerTraceOfContext(trace.contextId);
+        while (currentTrace) {
+          const errorInContext = dp.indexes.traces.errorByContext.get(currentTrace.contextId) || EmptyArray;
+          for (const errorTrace of errorInContext) {
+            if (potentialLeaves.has(errorTrace)) {
+              potentialLeaves.delete(errorTrace);
+              errorsOnStack.push(errorTrace);
+            }
+          }
+          currentTrace = dp.util.getCallerOrSchedulerTraceOfContext(currentTrace.contextId);
+        }
+        this._errorsByLeaf.set(trace, errorsOnStack);
+      }
     }
   }
 }

--- a/dbux-code/src/globalAnalysisView/GlobalAnalysisViewController.js
+++ b/dbux-code/src/globalAnalysisView/GlobalAnalysisViewController.js
@@ -39,10 +39,10 @@ export default class GlobalAnalysisViewController {
 
   async showError() {
     if (!this.children) {
-      await this.treeView.reveal(this.treeDataProvider.rootNodes[1], { select: false, expand: true });
+      await this.treeView.reveal(this.treeDataProvider.rootNodes[0], { select: false, expand: true });
     }
     this.errorTraceManager.showError();
-    const selectedTrace = this.treeDataProvider.rootNodes[1].getSelectedChildren();
+    const selectedTrace = this.treeDataProvider.rootNodes[0].getSelectedChildren();
     if (selectedTrace) {
       await this.treeView.reveal(selectedTrace);
     }

--- a/dbux-code/src/globalAnalysisView/nodes/GlobalErrorsChildNode.js
+++ b/dbux-code/src/globalAnalysisView/nodes/GlobalErrorsChildNode.js
@@ -1,0 +1,11 @@
+import TraceNode from '../../codeUtil/treeView/TraceNode';
+
+export default class GlobalErrorsChildNode extends TraceNode {
+  canHaveChildren() {
+    return true;
+  }
+
+  buildChildren() {
+    return this.childTraces.map(t => this.treeNodeProvider.buildNode(TraceNode, t, this));
+  }
+}

--- a/dbux-code/src/globalAnalysisView/nodes/GlobalErrorsNode.js
+++ b/dbux-code/src/globalAnalysisView/nodes/GlobalErrorsNode.js
@@ -1,7 +1,8 @@
-import TraceNode from '../../codeUtil/treeView/TraceNode';
 import BaseTreeViewNode from '../../codeUtil/treeView/BaseTreeViewNode';
+import GlobalErrorsChildNode from './GlobalErrorsChildNode';
 
 /** @typedef {import('@dbux/common/src/types/Trace').default} Trace */
+/** @typedef {import('../ErrorTraceManager').default} ErrorTraceManager */
 
 /** ###########################################################################
  * {@link GlobalErrorsNode}
@@ -14,6 +15,9 @@ export default class GlobalErrorsNode extends BaseTreeViewNode {
     return `Errors${icon}`;
   }
 
+  /**
+   * @type {ErrorTraceManager}
+   */
   get errorTraceManager() {
     return this.treeNodeProvider.controller.errorTraceManager;
   }
@@ -33,9 +37,11 @@ export default class GlobalErrorsNode extends BaseTreeViewNode {
   }
 
   buildChildren() {
-    const errorTraces = this.errorTraceManager.getAll();
-    return errorTraces.map(trace => {
-      return this.treeNodeProvider.buildNode(TraceNode, trace, this);
+    const leaves = this.errorTraceManager.getLeaves().reverse();
+
+    return leaves.map(leaf => {
+      const errorsOnStack = this.errorTraceManager.getErrorsByLeaf(leaf);
+      return this.treeNodeProvider.buildNode(GlobalErrorsChildNode, leaf, this, { childTraces: errorsOnStack });
     });
   }
 }

--- a/dbux-data/src/applications/allApplications.js
+++ b/dbux-data/src/applications/allApplications.js
@@ -198,6 +198,10 @@ export class AllApplications {
     return this.applicationSelection;
   }
 
+  get length() {
+    return this._all.length - 1;
+  }
+
   // ###########################################################################
   // event listeners
   // ###########################################################################

--- a/dbux-data/src/collections/TraceCollection.js
+++ b/dbux-data/src/collections/TraceCollection.js
@@ -218,7 +218,7 @@ export default class TraceCollection extends Collection {
          * performance hackfix
          * @see https://github.com/Domiii/dbux/issues/637
          */
-        return;
+        continue;
       }
 
       const previousTrace = this.dp.callGraph._getPreviousInContext(traceId);

--- a/dbux-data/src/collections/TraceCollection.js
+++ b/dbux-data/src/collections/TraceCollection.js
@@ -166,22 +166,31 @@ export default class TraceCollection extends Collection {
 
   /**
    * This is used to add error trace to indexes. Since trace.error is resolved in `postIndex`, we have to add these manually.
-   * @param {Trace} trace 
+   * @param {Trace[]} traces
    */
   recordErrorTraces(traces) {
-    const errorTraces = [];
-    for (const trace of traces) {
-      if (trace.error) {
+    const errorTraces = new Set();
+    let changedFlag = false;
+    for (const trace of this._newErrorTraces) {
+      if (trace.error && !errorTraces.has(trace)) {
         this.dp.indexes.traces.error.addEntry(trace);
         this.dp.indexes.traces.errorByContext.addEntry(trace);
         this.dp.indexes.traces.errorByRoot.addEntry(trace);
-        errorTraces.push(trace);
+        errorTraces.add(trace);
       }
     }
+    this._newErrorTraces = null;
 
-    if (errorTraces.length) {
+    if (changedFlag) {
+      /**
+       * hackfix: array might be unordered after insertion, needs to sort them manually
+       */
+      this.dp.indexes.traces.error.get(1).sort();
+    }
+
+    if (errorTraces.size) {
       const msg = errorTraces.map(t => `${this.dp.util.makeTraceInfo(t)}`).join('\n ');
-      this.logger.debug(`#### ${errorTraces.length} ERROR traces ####\n ${msg}`);
+      this.logger.debug(`#### ${errorTraces.size} ERROR traces ####\n ${msg}`);
     }
   }
 
@@ -189,6 +198,10 @@ export default class TraceCollection extends Collection {
    * @param {Trace[]} traces 
    */
   resolveErrorTraces(traces) {
+    /**
+     * hackfix: record new error traces in temp array, to correctly record previous trace in previous run
+     */
+    this._newErrorTraces = [];
     const { dp: { util } } = this;
     for (const trace of traces) {
       const {
@@ -199,6 +212,7 @@ export default class TraceCollection extends Collection {
       const traceType = util.getTraceType(traceId);
       if (TraceType.is.ThrowArgument(traceType)) {
         trace.error = true;
+        this._newErrorTraces.push(trace);
       }
 
       // if traces were disabled, there is nothing to do here
@@ -231,15 +245,18 @@ export default class TraceCollection extends Collection {
 
       if (TraceType.is.Catch(traceType)) {
         previousTrace.error = true;
+        this._newErrorTraces.push(previousTrace);
       }
       else if (TraceType.is.Finally(traceType)) {
         if (!TraceType.is.TryExit(previousTraceType) && !isTraceReturn(previousTraceType)) {
           previousTrace.error = true;
+          this._newErrorTraces.push(previousTrace);
         }
       }
       else if (isTracePop(traceType)) {
         if (!isTraceReturn(previousTraceType) && !isTraceFunctionExit(previousTraceType) && !TraceType.is.FinallyExit(previousTraceType)) {
           previousTrace.error = true;
+          this._newErrorTraces.push(previousTrace);
         }
       }
 

--- a/dbux-data/src/helpers/makeLabels.js
+++ b/dbux-data/src/helpers/makeLabels.js
@@ -98,7 +98,11 @@ const byType = {
   [TraceType.BlockEnd](/* trace, application */) {
     // const context = application.dataProvider.collections.executionContexts.getById(trace.contextId);
     return `⤴`;
-  }
+  },
+  [TraceType.Await](trace, application) {
+    const awaitArgumentTrace = application.dataProvider.collections.traces.getById(trace.traceId - 1);
+    return 'await ' + makeTraceLabel(awaitArgumentTrace);
+  },
 };
 
 /**

--- a/samples/__samplesInput__/nested_async-error.js
+++ b/samples/__samplesInput__/nested_async-error.js
@@ -1,0 +1,16 @@
+async function f() {
+  await 0;
+  await g();
+}
+
+async function g() {
+  await 0;
+  await h();
+}
+
+async function h() {
+  await 0;
+  throw new Error('An error');
+}
+
+f();

--- a/samples/__samplesInput__/try-catch-finally.js
+++ b/samples/__samplesInput__/try-catch-finally.js
@@ -1,0 +1,17 @@
+try {
+    console.log('try');
+    throw new Error('try');
+    return;
+}
+catch (err) {
+    console.log('catch');
+    // e();
+}
+finally {
+    console.log('finally');
+    // throw new Error('finally');
+}
+
+function e() {
+    throw new Error('e');
+}


### PR DESCRIPTION
* fix `resolveErrorTrace` unexpected termination
* fix `GlobalErrorNode` skips async errors
* nest error ancestors as children in `ErrorNode`
* move/copy `WebView` buttons

#618